### PR TITLE
catkin.bbclass: Stage /usr/etc sysroot direcotry 

### DIFF
--- a/classes/catkin.bbclass
+++ b/classes/catkin.bbclass
@@ -45,4 +45,10 @@ FILES_${PN}-dev += "\
     ${datadir}/${ROS_BPN}/*.template \
     "
 
+SYSROOT_PREPROCESS_FUNCS += "catkin_sysroot_preprocess"
+
+catkin_sysroot_preprocess () {
+    sysroot_stage_dir ${D}${prefix}/etc ${SYSROOT_DESTDIR}${prefix}/etc
+}
+
 BBCLASSEXTEND += "native"


### PR DESCRIPTION
The CMake generate_messages function from the genmsg package
detects the installed message generators via files in the
/usr/etc/ros/genmsg directory. Stage the /usr/etc directory
manually as it is not a common path.

Fixed #50

Signed-off-by: Stefan Herbrechtsmeier stefan@herbrechtsmeier.net
