### PR TITLE
genpy: Setup python binary path during runtime via find_program 

### DIFF
--- a/recipes-ros/genpy/genpy/0001-genpy-extras.cmake.em-use-find_program-for-GENxxx_PY_BIN.patch
+++ b/recipes-ros/genpy/genpy/0001-genpy-extras.cmake.em-use-find_program-for-GENxxx_PY_BIN.patch
@@ -1,0 +1,20 @@
+diff -Naur a/cmake/genpy-extras.cmake.em b/cmake/genpy-extras.cmake.em
+--- a/cmake/genpy-extras.cmake.em	2012-12-22 03:39:57.000000000 +0100
++++ b/cmake/genpy-extras.cmake.em	2013-05-22 10:46:08.000000000 +0200
+@@ -1,11 +1,16 @@
+ @[if DEVELSPACE]@
+ # bin dir variables in develspace
+ set(GENPY_BIN_DIR @(CMAKE_CURRENT_SOURCE_DIR)/scripts)
++set(CATKIN_FIND_ROOT_PATH_MODE NO_CMAKE_FIND_ROOT_PATH)
+ @[else]@
+ # bin dir variables in installspace
+ set(GENPY_BIN_DIR @(CMAKE_INSTALL_PREFIX)/@(CATKIN_PACKAGE_BIN_DESTINATION))
++set(CATKIN_FIND_ROOT_PATH_MODE "")
+ @[end if]@
+ 
++find_program(GENMSG_PY_BIN genmsg_py.py PATHS ${GENPY_BIN_DIR} NO_DEFAULT_PATH CATKIN_FIND_ROOT_PATH_MODE)
++find_program(GENSRV_PY_BIN gensrv_py.py PATHS ${GENPY_BIN_DIR} NO_DEFAULT_PATH CATKIN_FIND_ROOT_PATH_MODE)
++
+ set(GENMSG_PY_BIN ${GENPY_BIN_DIR}/genmsg_py.py)
+ set(GENSRV_PY_BIN ${GENPY_BIN_DIR}/gensrv_py.py)
+ 

--- a/recipes-ros/genpy/genpy_0.4.10.bb
+++ b/recipes-ros/genpy/genpy_0.4.10.bb
@@ -7,7 +7,10 @@ DEPENDS = "genmsg-native"
 RDEPENDS_${PN} = "python-math genmsg python-shell"
 RDEPENDS_${PN}_class-native = ""
 
-SRC_URI = "https://github.com/ros/${BPN}/archive/${PV}.tar.gz;downloadfilename=${BP}.tar.gz"
+PR = "r1"
+
+SRC_URI = "https://github.com/ros/${BPN}/archive/${PV}.tar.gz;downloadfilename=${BP}.tar.gz \
+           file://0001-genpy-extras.cmake.em-use-find_program-for-GENxxx_PY_BIN.patch"
 SRC_URI[md5sum] = "23915e68167ba6d58c65920bfabd2fad"
 SRC_URI[sha256sum] = "6c77bde606c9637b0fa9e6f4ed85882e98547500a7472d2643bcc52b6c8a8b78"
 


### PR DESCRIPTION
The python binary path for genmsg_py.py and gensrv_py.py are hard
coded in the CMake file and don't work during cross compile. Setup
them via find_program during runtime.

This fix #69 and the following error:
**\* No rule to make target `/usr/lib/genpy/genmsg_py.py', needed by
`devel/lib/python2.7/site-packages/std_msgs/msg/_Bool.py'.  Stop.
