### PR TITLE
genmsg: Update to handle a list of msg include dirs relative

### DIFF
--- a/recipes-ros/genmsg/genmsg/0001-modify-msg-file-handling-to-reference-them-relatively.patch
+++ b/recipes-ros/genmsg/genmsg/0001-modify-msg-file-handling-to-reference-them-relatively.patch
@@ -1,6 +1,6 @@
 diff -Naur a/cmake/genmsg-extras.cmake.em b/cmake/genmsg-extras.cmake.em
---- a/cmake/genmsg-extras.cmake.em	2013-01-19 20:01:11.000000000 +0100
-+++ b/cmake/genmsg-extras.cmake.em	2013-03-13 16:39:51.000000000 +0100
+--- a/cmake/genmsg-extras.cmake.em	2013-05-23 09:45:59.000000000 +0200
++++ b/cmake/genmsg-extras.cmake.em	2013-05-23 09:48:56.000000000 +0200
 @@ -172,8 +172,7 @@
      ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/${PROJECT_NAME}-msg-paths.cmake
      @@ONLY)
@@ -12,11 +12,14 @@ diff -Naur a/cmake/genmsg-extras.cmake.em b/cmake/genmsg-extras.cmake.em
      ${genmsg_CMAKE_DIR}/pkg-msg-paths.cmake.in
      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/installspace/${PROJECT_NAME}-msg-paths.cmake
 diff -Naur a/cmake/pkg-msg-paths.cmake.in b/cmake/pkg-msg-paths.cmake.in
---- a/cmake/pkg-msg-paths.cmake.in	2013-01-19 20:01:11.000000000 +0100
-+++ b/cmake/pkg-msg-paths.cmake.in	2013-03-13 16:37:32.000000000 +0100
-@@ -1,2 +1,5 @@
- set(@PROJECT_NAME@_MSG_INCLUDE_DIRS @PKG_MSG_INCLUDE_DIRS@)
-+if(NOT IS_ABSOLUTE ${@PROJECT_NAME@_MSG_INCLUDE_DIRS})
-+  set(@PROJECT_NAME@_MSG_INCLUDE_DIRS ${@PROJECT_NAME@_DIR}/../${@PROJECT_NAME@_MSG_INCLUDE_DIRS})
+--- a/cmake/pkg-msg-paths.cmake.in	2013-05-23 09:45:59.000000000 +0200
++++ b/cmake/pkg-msg-paths.cmake.in	2013-05-23 11:03:04.000000000 +0200
+@@ -1,2 +1,7 @@
+-set(@PROJECT_NAME@_MSG_INCLUDE_DIRS @PKG_MSG_INCLUDE_DIRS@)
++if(@DEVELSPACE@)
++  set(@PROJECT_NAME@_MSG_INCLUDE_DIRS @PKG_MSG_INCLUDE_DIRS@)
++else()
++  _prepend_path(${@PROJECT_NAME@_DIR}/.. "@PKG_MSG_INCLUDE_DIRS@" INCLUDE_DIRS_W_PATH)
++  set(@PROJECT_NAME@_MSG_INCLUDE_DIRS "${INCLUDE_DIRS_W_PATH}")
 +endif()
  set(@PROJECT_NAME@_MSG_DEPENDENCIES @ARG_DEPENDENCIES@)

--- a/recipes-ros/genmsg/genmsg_0.4.17.bb
+++ b/recipes-ros/genmsg/genmsg_0.4.17.bb
@@ -3,6 +3,8 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
+PR = "r1"
+
 SRC_URI = "https://github.com/ros/${BPN}/archive/${PV}.tar.gz;downloadfilename=${BP}.tar.gz \
            file://0001-modify-msg-file-handling-to-reference-them-relatively.patch \
            "


### PR DESCRIPTION
The last patched version assumes that the variable msg include dirs
is only one directory and not a list of directories. This leads to
errors if generate_message(DIRECTORY ...) occurs twice in the
CMakeLists files.

Make Error at build/devel/share/cmake/...-msg-paths.cmake:2 (if):
| if given arguments:
|
| "NOT" "IS_ABSOLUTE" "" ""

Fixed issue #72.
