### PR TITLE
rostest: add missing dependency on python-nose

### DIFF
--- a/classes/catkin.bbclass
+++ b/classes/catkin.bbclass
@@ -48,6 +48,12 @@ FILES_${PN}-dbg += "\
     ${libdir}/${ROS_BPN}/.debug/* \
     "
 
+PACKAGES += "${PN}-commonlisp"
+
+FILES_${PN}-commonlisp += " \
+    ${datadir}/common-lisp/ \
+    "
+
 SYSROOT_PREPROCESS_FUNCS += "catkin_sysroot_preprocess"
 
 catkin_sysroot_preprocess () {

--- a/recipes-ros/ros-comm/rostest_1.9.41.bb
+++ b/recipes-ros/ros-comm/rostest_1.9.41.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "boost rosunit-native"
+DEPENDS = "boost python-nose rosunit-native"
 
 require ros-comm.inc
 


### PR DESCRIPTION
| CMake Warning at /build/v2012.12/build/tmp-angstrom_v2012_12-eglibc/sysroots/x86_64-linux/usr/share/catkin/cmake/test/nosetests.cmake:90 (message):
|   nosetests not found, Python tests can not be run (try installing package
|   'python-nose')

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
