### PR TITLE
rostest: rostest depends on rostest-native (resolves #83)

### DIFF
--- a/recipes-ros/ros-comm/rostest-native_1.9.41.bb
+++ b/recipes-ros/ros-comm/rostest-native_1.9.41.bb
@@ -1,0 +1,7 @@
+require rostest.inc
+
+DEPENDS = "boost-native rosunit-native"
+
+inherit native
+
+OECMAKE_EXTRA_ROOT_PATH = "${OECMAKE_BUILDPATH}/devel"

--- a/recipes-ros/ros-comm/rostest.inc
+++ b/recipes-ros/ros-comm/rostest.inc
@@ -1,0 +1,10 @@
+DESCRIPTION = "Integration test suite based on roslaunch that is compatible with xUnit frameworks."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require ros-comm.inc
+
+BBCLASSEXTEND = ""
+
+S = "${WORKDIR}/ros_comm-${PV}/tools/${BPN}"

--- a/recipes-ros/ros-comm/rostest_1.9.41.bb
+++ b/recipes-ros/ros-comm/rostest_1.9.41.bb
@@ -1,12 +1,5 @@
-DESCRIPTION = "Integration test suite based on roslaunch that is compatible with xUnit frameworks."
-SECTION = "devel"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+require rostest.inc
 
-DEPENDS = "boost python-nose rosunit-native"
+DEPENDS = "boost python-nose rostest-native"
 
-require ros-comm.inc
 
-S = "${WORKDIR}/ros_comm-${PV}/tools/${BPN}"
-
-OECMAKE_EXTRA_ROOT_PATH_class-native = "${OECMAKE_BUILDPATH}/devel"


### PR DESCRIPTION
The rostest package requires that the rostest executable can be
found by cmake's find during configure. Hence, rostest depends on
rostest-native.
To implement this, rostest is refactored into a common file
rostest.inc and the specific dependencies for rostest and
rostest-native.

This commit resolves issue #83.
