### PR TITLE
provide class for gtest

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,7 @@ CONTRIBUTORS
   Tobias Weigl, BMW Car IT GmbH <tobias.weigl@bmw-carit.de>
   Kartik Mohta <kartikmohta@gmail.com>
   Koen Kooi <koen@dominion.thruhere.net>
+  Tobias Henkel, BMW Car IT GmbH <tobias.henkel@bmw-carit.de>
 
 HOW TO CONTRIBUTE
 

--- a/classes/gtest.bbclass
+++ b/classes/gtest.bbclass
@@ -1,0 +1,13 @@
+# This class injects google test in the directory given by
+# GTEST_DESTDIR (S by default)
+
+SRC_URI += "https://googletest.googlecode.com/files/gtest-1.6.0.zip;name=gtest"
+
+SRC_URI[gtest.md5sum] = "4577b49f2973c90bf9ba69aa8166b786"
+SRC_URI[gtest.sha256sum] = "5ec97df8e75b4ee796604e74716d1b50582beba22c5502edd055a7e67a3965d8"
+
+GTEST_DESTDIR ?= "${S}"
+
+do_configure_prepend () {
+    ln -s ${WORKDIR}/gtest-1.6.0 ${GTEST_DESTDIR}/gtest
+}

--- a/recipes-ros/class-loader/class-loader_0.2.0.bb
+++ b/recipes-ros/class-loader/class-loader_0.2.0.bb
@@ -19,4 +19,4 @@ DEPENDS = "console-bridge libpoco"
 
 S = "${WORKDIR}/${ROS_BP}"
 
-inherit catkin
+inherit catkin gtest

--- a/recipes-ros/geometry/geometry.inc
+++ b/recipes-ros/geometry/geometry.inc
@@ -2,6 +2,6 @@ SRC_URI = "https://github.com/ros/geometry/archive/${PV}.tar.gz;downloadfilename
 SRC_URI[md5sum] = "e7df8e2b209881c3cf262c8ccf7598d5"
 SRC_URI[sha256sum] = "862918e3997b90570c282f29b03a9f70b4a354f1447fdce8c8940666e1811239"
 
-inherit catkin
+inherit catkin gtest
 
 S = "${WORKDIR}/geometry-${PV}/${ROS_BPN}"


### PR DESCRIPTION
These commit resolves problems with gtest. The problems were not visible before, because many packages skip gtests silently if gtest is not provided.
Only a few ROS packages require that gtest is actually provided and fail if gtest is not provided.
