### PR TITLE
rostest: rostest depends on rostest-native (resolves #83)

### DIFF
--- a/recipes-ros/ros-comm/rostest_1.9.41.bb
+++ b/recipes-ros/ros-comm/rostest_1.9.41.bb
@@ -3,7 +3,8 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "boost python-nose rosunit-native"
+DEPENDS = "boost python-nose rostest-native"
+DEPENDS_class-native = "boost-native rosunit-native"
 
 require ros-comm.inc
 


### PR DESCRIPTION
The rostest package requires that the rostest executable can be
found by cmake's find during configure. Hence, rostest depends on
rostest-native.
To implement this, rostest and rostest-native are defined with
different dependencies.

This commit resolves issue #83.
