### PR TITLE
catkin: adjustment for native recipe (cf. discussion #101)

### DIFF
--- a/recipes-ros/catkin/catkin_git.bb
+++ b/recipes-ros/catkin/catkin_git.bb
@@ -4,6 +4,8 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "cmake python-empy python-catkin-pkg"
+RDEPENDS_${PN}_class-native = ""
+
 RDEPENDS_${PN} = "cmake packagegroup-core-buildessential \
     python-catkin-pkg python-argparse python-misc python-multiprocessing \
     python-shell python-subprocess python-xml"


### PR DESCRIPTION
The native catkin recipe has no runtime dependency on
the native version of packagegroup-core-buildessential.
