### PR TITLE
Preparations for PCL and pcl-ros package

### DIFF
--- a/recipes-devtools/log4cxx/log4cxx_0.10.0.bb
+++ b/recipes-devtools/log4cxx/log4cxx_0.10.0.bb
@@ -10,10 +10,11 @@ SRC_URI = "http://archive.apache.org/dist/logging/log4cxx/0.10.0/apache-log4cxx-
   file://0001-log4cxx_0-10-0_add-missing-includes.patch \
   file://0002-Remove-duplicates-from-makefile.patch \
   file://0003-log4cxx-0.10.0-add_stdio_header.patch"
+SRC_URI[md5sum] = "b30ffb8da3665178e68940ff7a61084c"
+SRC_URI[sha256sum] = "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
 
-S = "${WORKDIR}/apache-${PN}-${PV}"
+S = "${WORKDIR}/apache-${BP}"
 
 inherit autotools pkgconfig
 
-SRC_URI[md5sum] = "b30ffb8da3665178e68940ff7a61084c"
-SRC_URI[sha256sum] = "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
+BBCLASSEXTEND += "native"

--- a/recipes-devtools/python/python-native_2.7.3.bbappend
+++ b/recipes-devtools/python/python-native_2.7.3.bbappend
@@ -1,0 +1,1 @@
+RPROVIDES += "python-xml-native"

--- a/recipes-devtools/python/python-rospkg_1.0.15.bb
+++ b/recipes-devtools/python/python-rospkg_1.0.15.bb
@@ -10,7 +10,7 @@ SRC_URI[sha256sum] = "f8be5a9d74f7e656d38b2c3b44b7e367fce4001d613ca3fbfcbb87c493
 
 S = "${WORKDIR}/${SRCNAME}-${PV}"
 
-RDEPENDS_${PN} += "python-modules"
+RDEPENDS_${PN} += "python-xml"
 
 inherit setuptools
 

--- a/recipes-devtools/python/python-rospkg_1.0.15.bb
+++ b/recipes-devtools/python/python-rospkg_1.0.15.bb
@@ -15,6 +15,5 @@ RDEPENDS_${PN} += "python-xml"
 inherit setuptools
 
 DEPENDS += "python"
-DEPENDS_class-native  += "python-native"
 BBCLASSEXTEND = "native"
 

--- a/recipes-extended/libflann/libflann_1.8.4.bb
+++ b/recipes-extended/libflann/libflann_1.8.4.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "a library for performing fast approximate nearest neighbor searches in high dimensional spaces"
+AUTHOR = "Marius Muja and David G. Lowe"
+HOMEPAGE = "http://www.cs.ubc.ca/~mariusm/index.php/FLANN/FLANN"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=040a44ba915aa6b3b099ea189c7b7e20"
+
+SRC_URI = "http://people.cs.ubc.ca/~mariusm/uploads/FLANN/flann-1.8.4-src.zip"
+SRC_URI[md5sum] = "a0ecd46be2ee11a68d2a7d9c6b4ce701"
+SRC_URI[sha256sum] = "dfbb9321b0d687626a644c70872a2c540b16200e7f4c7bd72f91ae032f445c08"
+
+S = "${WORKDIR}/flann-${PV}-src"
+
+inherit cmake

--- a/recipes-ros/dynamic-reconfigure/dynamic-reconfigure_1.5.32.bb
+++ b/recipes-ros/dynamic-reconfigure/dynamic-reconfigure_1.5.32.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "\
+This unary stack contains the dynamic_reconfigure package which provides a means to change \
+node parameters at any time without having to restart the node."
+
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+SRC_URI = "https://github.com/ros/${ROS_BPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_BP}.tar.gz"
+SRC_URI[md5sum] = "9061fd30e5a04e8376eaddffaae86b07"
+SRC_URI[sha256sum] = "4203b0a8389d9ac3203110b507d23fa353262cf26253f40abece6418d6c2bdd4"
+
+DEPENDS = "roscpp std-msgs"
+RDEPENDS_${PN} = "roslib"
+
+S = "${WORKDIR}/${ROS_BP}"
+
+inherit catkin

--- a/recipes-ros/dynamic-reconfigure/dynamic-reconfigure_1.5.32.bb
+++ b/recipes-ros/dynamic-reconfigure/dynamic-reconfigure_1.5.32.bb
@@ -10,7 +10,7 @@ SRC_URI = "https://github.com/ros/${ROS_BPN}/archive/${PV}.tar.gz;downloadfilena
 SRC_URI[md5sum] = "9061fd30e5a04e8376eaddffaae86b07"
 SRC_URI[sha256sum] = "4203b0a8389d9ac3203110b507d23fa353262cf26253f40abece6418d6c2bdd4"
 
-DEPENDS = "roscpp std-msgs"
+DEPENDS = "roscpp std-msgs roslib"
 RDEPENDS_${PN} = "roslib"
 
 S = "${WORKDIR}/${ROS_BP}"

--- a/recipes-ros/nodelet-core/nodelet-core.inc
+++ b/recipes-ros/nodelet-core/nodelet-core.inc
@@ -1,0 +1,7 @@
+SRC_URI = "https://github.com/ros/nodelet_core/archive/${PV}.tar.gz;downloadfilename=${BP}.tar.gz"
+SRC_URI[md5sum] = "840b98ace89034029569f20a2a41af05"
+SRC_URI[sha256sum] = "4cc5a76ec90b0610b794128509923beba9b6dee2cb18fdeb6fd3ecc409051262"
+
+S = "${WORKDIR}/nodelet_core-${PV}/${ROS_BPN}"
+
+inherit catkin

--- a/recipes-ros/nodelet-core/nodelet-topic-tools_1.7.15.bb
+++ b/recipes-ros/nodelet-core/nodelet-topic-tools_1.7.15.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "This package contains common nodelet tools such as a mux, demux and throttle."
+
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "dynamic-reconfigure-native"
+
+require nodelet-core.inc

--- a/recipes-ros/nodelet-core/nodelet_1.7.15.bb
+++ b/recipes-ros/nodelet-core/nodelet_1.7.15.bb
@@ -11,12 +11,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-SRC_URI = "https://github.com/ros/nodelet_core/archive/${PV}.tar.gz;downloadfilename=${BP}.tar.gz"
-SRC_URI[md5sum] = "840b98ace89034029569f20a2a41af05"
-SRC_URI[sha256sum] = "4cc5a76ec90b0610b794128509923beba9b6dee2cb18fdeb6fd3ecc409051262"
-
 DEPENDS = "bondcpp boost message-generation pluginlib rosconsole roscpp rospy std-msgs libtinyxml"
 
-S = "${WORKDIR}/nodelet_core-${PV}/${PN}"
-
-inherit catkin
+require nodelet-core.inc

--- a/recipes-ros/rospack/rospack_2.1.16.bb
+++ b/recipes-ros/rospack/rospack_2.1.16.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=6;endline=6;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "boost python-native libtinyxml"
+DEPENDS = "boost python-rospkg-native libtinyxml"
 
 SRC_URI = "https://github.com/ros/${BPN}/archive/${PV}.tar.gz;downloadfilename=${BP}.tar.gz"
 SRC_URI[md5sum] = "1383bdce36fe6319884e7b158c22d8b4"


### PR DESCRIPTION
The pcl_ros package requires nodelet_topic_tools. The nodelet_topic_tools require dynamic_reconfigure_native. For dynamic_reconfigure_native, further existing packages must provide a native recipe. The point cloud library requires libflann.
Currently, bitbake nodelet-topic-tools does not configure, but I would like to put the current state upstream to discuss the issue publicly.
The PCL and pcl-ros package are provided in a future pull request, as they are still in my own development.
