### PR TITLE
yaml-cpp: incorporated recipe from Kartik Mohta's repository

### DIFF
--- a/README
+++ b/README
@@ -98,6 +98,9 @@ REDISTRIBUTIONS
   The eigen recipe originated from the recipe in Kartik Mohta's OpenEmbedded layer
   (cf. https://github.com/kartikmohta/meta-km/tree/master/recipes-extended/eigen)
   licensed with the MIT License.
+  The yaml-cpp recipe originated from the recipe in Kartik Mohta's OpenEmbedded layer
+  (cf. https://github.com/kartikmohta/meta-km/blob/master/recipes-devtools/yaml-cpp/yaml-cpp_0.3.0.bb)
+  licensed with the MIT License.
   The core-image-ros-* recipes originated from the core-image-minimal recipe in OpenEmbedded Core
   (cf. http://cgit.openembedded.org/openembedded-core/tree/meta/recipes-core/images/core-image-minimal.bb)
   licensed with the MIT License.

--- a/recipes-devtools/yaml-cpp/yaml-cpp_0.3.0.bb
+++ b/recipes-devtools/yaml-cpp/yaml-cpp_0.3.0.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec"
+HOMEPAGE = "http://code.google.com/p/yaml-cpp/"
+SECTION = "libs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://license.txt;md5=7c6a629da965ebdfba9f6fdb76ab8ab4"
+
+PR = "r0"
+
+S = "${WORKDIR}/${PN}"
+
+SRC_URI = "http://yaml-cpp.googlecode.com/files/yaml-cpp-${PV}.tar.gz"
+
+SRC_URI[md5sum] = "9aa519205a543f9372bf4179071c8ac6"
+SRC_URI[sha256sum] = "2cd038b5a1583b6745e949e196fba525f6d0d5fd340566585fde24fc7e117b82"
+
+EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON"
+
+inherit cmake


### PR DESCRIPTION
This commit adds the yaml-cpp recipe from the repository at
https://github.com/kartikmohta/meta-km. The file is licensed
with the MIT license
(cf. https://github.com/kartikmohta/meta-km/blob/master/LICENSE).

The original recipe can be found at
https://github.com/kartikmohta/meta-km/blob/master/recipes-devtools/yaml-cpp/yaml-cpp_0.3.0.bb

The README file acknowledges Kartik Mohta's contribution and names
him as a contributor.
