### PR TITLE
Added recipes for ROSSerial

### DIFF
--- a/recipes-ros/rosserial/rosserial-arduino_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-arduino_0.5.3.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Arduino Library with examples."
+DESCRIPTION = "Libraries and examples for ROSserial usage on Arduino/AVR Platforms."
 SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"

--- a/recipes-ros/rosserial/rosserial-arduino_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-arduino_0.5.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Arduino Library with examples."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "std-msgs sensor-msgs geometry-msgs nav-msgs rosserial-client message-generation"
+
+require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-client_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-client_0.5.3.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Client."
+DESCRIPTION = "Generalized client side source for rosserial."
 SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"

--- a/recipes-ros/rosserial/rosserial-client_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-client_0.5.3.bb
@@ -3,6 +3,4 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = ""
-
 require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-client_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-client_0.5.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Client."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = ""
+
+require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-embeddedlinux_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-embeddedlinux_0.5.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Embedded Linux Examples."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "std-msgs sensor-msgs geometry-msgs nav-msgs rosserial-client"
+
+require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-embeddedlinux_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-embeddedlinux_0.5.3.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Embedded Linux Examples."
+DESCRIPTION = "Libraries and examples for ROSserial usage on Embedded Linux Enviroments"
 SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"

--- a/recipes-ros/rosserial/rosserial-msgs_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-msgs_0.5.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Messages."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "message-generation"
+
+require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-msgs_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-msgs_0.5.3.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Messages."
+DESCRIPTION = "Messages for automatic topic configuration using rosserial."
 SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"

--- a/recipes-ros/rosserial/rosserial-python_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-python_0.5.3.bb
@@ -3,6 +3,4 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = ""
-
 require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-python_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-python_0.5.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Python."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = ""
+
+require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-python_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-python_0.5.3.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Python."
+DESCRIPTION = "A Python-based implementation of the ROS serial protocol."
 SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"

--- a/recipes-ros/rosserial/rosserial-xbee_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-xbee_0.5.3.bb
@@ -1,4 +1,12 @@
-DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Xbee."
+DESCRIPTION = "
+     rosserial_xbee provides tools to do point to multipoint communication
+     between rosserial nodes connected to an xbee.  All of the nodes
+     communicate back to a master xbee connected to a computer running
+     ROS.  This software currently only works with Series 1 Xbees.
+     
+     This pkg includes python code from the python-xbee project:
+     http://code.google.com/p/python-xbee/"
+     
 SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=17;endline=17;md5=d566ef916e9dedc494f5f793a6690ba5"

--- a/recipes-ros/rosserial/rosserial-xbee_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-xbee_0.5.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS package for the BeagleBone for ROS Serial Xbee."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=17;endline=17;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = ""
+
+require rosserial.inc

--- a/recipes-ros/rosserial/rosserial-xbee_0.5.3.bb
+++ b/recipes-ros/rosserial/rosserial-xbee_0.5.3.bb
@@ -3,6 +3,4 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=17;endline=17;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = ""
-
 require rosserial.inc

--- a/recipes-ros/rosserial/rosserial.inc
+++ b/recipes-ros/rosserial/rosserial.inc
@@ -1,3 +1,4 @@
+DESCRIPTION="Metapackage for core of rosserial."
 SRC_URI = "https://github.com/ros-drivers/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${PV}.tar.gz"
 SRC_URI[md5sum] = "0a6191b2c5ecf9de527a9365299c59b2"
 SRC_URI[sha256sum] = "b00fa3871f204e300dcd16a8847f3a81d64f57bb2ae96b3f3c41f77945e923be"

--- a/recipes-ros/rosserial/rosserial.inc
+++ b/recipes-ros/rosserial/rosserial.inc
@@ -2,7 +2,6 @@ SRC_URI = "https://github.com/ros-drivers/${ROS_SPN}/archive/${PV}.tar.gz;downlo
 SRC_URI[md5sum] = "0a6191b2c5ecf9de527a9365299c59b2"
 SRC_URI[sha256sum] = "b00fa3871f204e300dcd16a8847f3a81d64f57bb2ae96b3f3c41f77945e923be"
 
-
 S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
 
 inherit catkin

--- a/recipes-ros/rosserial/rosserial.inc
+++ b/recipes-ros/rosserial/rosserial.inc
@@ -1,0 +1,10 @@
+SRC_URI = "https://github.com/ros-drivers/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${PV}.tar.gz"
+SRC_URI[md5sum] = "0a6191b2c5ecf9de527a9365299c59b2"
+SRC_URI[sha256sum] = "b00fa3871f204e300dcd16a8847f3a81d64f57bb2ae96b3f3c41f77945e923be"
+
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "rosserial"


### PR DESCRIPTION
They all compile but only tested 
rosserial-msgs
rosserial-python

Left out 
rosserial-server - doesn't compile

I removed depends on gcc-avr and avr-libc from rosserial-arduino since I would think only needed if you are compiling a sketch since it compiles find and its just for the Arduino Libraries. 

Thanks.
