### PR TITLE
packagegroup-ros-world: removed urdfdom-headers and added build image

### DIFF
--- a/recipes-core/images/core-image-ros-world.bb
+++ b/recipes-core/images/core-image-ros-world.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "An image with packagegroup-ros-world installed"
+
+IMAGE_INSTALL = "packagegroup-core-boot ${ROOTFS_PKGMANAGE_BOOTSTRAP} ${CORE_IMAGE_EXTRA_INSTALL}"
+
+IMAGE_LINGUAS = " "
+
+LICENSE = "MIT"
+
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+
+# remove not needed ipkg informations
+ROOTFS_POSTPROCESS_COMMAND += "remove_packaging_data_files"
+
+IMAGE_INSTALL += "packagegroup-ros-world"

--- a/recipes-ros/packagegroups/packagegroup-ros-world.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-world.bb
@@ -49,7 +49,6 @@ RDEPENDS_${PN} = "\
     theora-image-transport \
     cmake-modules \
     rosconsole-bridge \
-    urdfdom-headers \
     urdfdom \
     control-msgs \
     realtime-tools \


### PR DESCRIPTION
This fixes the issue discussed at https://github.com/bmwcarit/meta-ros/issues/177

Note that I also added an additional image that installs packagegroup-ros-world. This allows easy testing of whether packagegroup-ros-world installs correctly. Feel free remove this part if you think this is not useful.
