### PR TITLE
libfreenect: force libraries always into /usr/lib (resolves #187,#188)

### DIFF
--- a/recipes-extended/libfreenect/libfreenect_0.2.0.bb
+++ b/recipes-extended/libfreenect/libfreenect_0.2.0.bb
@@ -12,5 +12,8 @@ inherit cmake
 
 S = "${WORKDIR}/libfreenect-${PV}"
 
+#force libs always into /usr/lib, even when compiling on 64bit arch
+EXTRA_OECMAKE += " -DLIB_SUFFIX=''"
+
 FILES_${PN}-dev += "${libdir}/fakenect/libfreenect.so.0.1 ${libdir}/fakenect/libfreenect.so ${libdir}/fakenect/libfreenect.so.0.1.2" 
 FILES_${PN}-dbg += "${libdir}/fakenect/.debug"


### PR DESCRIPTION
Patch confirmed by building libfreenect and freenect-camera launch on both qemux86 and qemux86-64.
