### PR TITLE
python-orocos-kdl: initial commit (resolves #203)

### DIFF
--- a/recipes-extended/kdl/kdl.inc
+++ b/recipes-extended/kdl/kdl.inc
@@ -1,0 +1,9 @@
+SRC_URI = "git://github.com/orocos/orocos_kinematics_dynamics.git"
+SRCREV = "15fb082c10b58078841c14c067ac55f592733447"
+PV = "1.1.102+git${SRCREV}"
+
+S = "${WORKDIR}/git/${@d.getVar('BPN', True).replace('-', '_')}"
+
+inherit cmake
+
+ROS_SPN = "kdl"

--- a/recipes-extended/kdl/orocos-kdl_1.1.102-1.bb
+++ b/recipes-extended/kdl/orocos-kdl_1.1.102-1.bb
@@ -3,13 +3,7 @@ SECTION = "devel"
 LICENSE = "LGPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a8ffd58e6eb29a955738b8fcc9e9e8f2"
 
-SRC_URI = "git://github.com/orocos/orocos_kinematics_dynamics.git"
-SRCREV = "15fb082c10b58078841c14c067ac55f592733447"
-PV = "1.1.102+git${SRCREV}"
-
-S = "${WORKDIR}/git/orocos_kdl"
-
-inherit cmake
+require kdl.inc
 
 FILES_${PN}-dev += "/usr/share/orocos_kdl/package.xml /usr/share/orocos_kdl/orocos_kdl-config.cmake"
 

--- a/recipes-extended/kdl/orocos-kdl_1.1.102-1.bb
+++ b/recipes-extended/kdl/orocos-kdl_1.1.102-1.bb
@@ -3,12 +3,14 @@ SECTION = "devel"
 LICENSE = "LGPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a8ffd58e6eb29a955738b8fcc9e9e8f2"
 
-require kdl.inc
+DEPENDS = "libeigen"
 
-FILES_${PN}-dev += "/usr/share/orocos_kdl/package.xml /usr/share/orocos_kdl/orocos_kdl-config.cmake"
+require kdl.inc
 
 do_install_append() {
         # remove sysroot library path from pkgconfig files
         sed -i -e 's#${STAGING_INCDIR}#${includedir}#g' \
                    ${D}${libdir}/pkgconfig/*.pc
 }
+
+FILES_${PN}-dev += "${datadir}/orocos_kdl/*"

--- a/recipes-extended/kdl/python-orocos-kdl/0001-findSIP-fix.patch
+++ b/recipes-extended/kdl/python-orocos-kdl/0001-findSIP-fix.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/FindSIP.cmake b/cmake/FindSIP.cmake
+index 53e2888..8f94cf5 100644
+--- a/cmake/FindSIP.cmake
++++ b/cmake/FindSIP.cmake
+@@ -31,17 +31,26 @@ IF(SIP_VERSION)
+   SET(SIP_FOUND TRUE)
+ ELSE(SIP_VERSION)
+ 
+-  FIND_FILE(_find_sip_py FindSIP.py PATHS ${CMAKE_MODULE_PATH})
++  FIND_FILE(_find_sip_py FindSIP.py PATHS ${CMAKE_MODULE_PATH} NO_CMAKE_FIND_ROOT_PATH)
+ 
+   EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} ${_find_sip_py} OUTPUT_VARIABLE sip_config)
+   IF(sip_config)
+     STRING(REGEX REPLACE "^sip_version:([^\n]+).*$" "\\1" SIP_VERSION ${sip_config})
+     STRING(REGEX REPLACE ".*\nsip_version_str:([^\n]+).*$" "\\1" SIP_VERSION_STR ${sip_config})
+-    STRING(REGEX REPLACE ".*\nsip_bin:([^\n]+).*$" "\\1" SIP_EXECUTABLE ${sip_config})
+     IF(NOT SIP_DEFAULT_SIP_DIR)
+         STRING(REGEX REPLACE ".*\ndefault_sip_dir:([^\n]+).*$" "\\1" SIP_DEFAULT_SIP_DIR ${sip_config})
+     ENDIF(NOT SIP_DEFAULT_SIP_DIR)
+-    STRING(REGEX REPLACE ".*\nsip_inc_dir:([^\n]+).*$" "\\1" SIP_INCLUDE_DIR ${sip_config})
++
++    IF(CMAKE_CROSSCOMPILING)
++      FIND_PROGRAM(SIP_EXECUTABLE sip)
++      STRING(REGEX REPLACE ".*\nsip_inc_dir:([^\n]+).*$" "\\1" SIP_INCLUDE_DIR ${sip_config})
++      LIST(GET CMAKE_FIND_ROOT_PATH 0 SIP_SYSROOT)
++      SET(SIP_INCLUDE_DIR "${SIP_SYSROOT}${SIP_INCLUDE_DIR}")
++    ELSE(CMAKE_CROSSCOMPILING)
++      STRING(REGEX REPLACE ".*\nsip_bin:([^\n]+).*$" "\\1" SIP_EXECUTABLE ${sip_config})
++      STRING(REGEX REPLACE ".*\nsip_inc_dir:([^\n]+).*$" "\\1" SIP_INCLUDE_DIR ${sip_config})
++    ENDIF(CMAKE_CROSSCOMPILING)
++
+     SET(SIP_FOUND TRUE)
+   ENDIF(sip_config)
+ 

--- a/recipes-extended/kdl/python-orocos-kdl_1.1.102-1.bb
+++ b/recipes-extended/kdl/python-orocos-kdl_1.1.102-1.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "This package contains the python bindings PyKDL for the Kinematics and Dynamics Library (KDL), distributed by the Orocos Project."
+SECTION = "devel"
+LICENSE = "LGPLv2"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=46ee8693f40a89a31023e97ae17ecf19"
+
+DEPENDS = "sip-native python-sip orocos-kdl"
+
+require kdl.inc
+
+SRC_URI += "file://0001-findSIP-fix.patch"
+
+inherit pythonnative
+
+FILES_${PN} += "${libdir}/python*/dist-packages/PyKDL.so"
+FILES_${PN}-dev += "${datadir}/python_orocos_kdl/*"
+FILES_${PN}-dbg += "${libdir}/python*/dist-packages/.debug/*"
+
+RDEPENDS_{PN} = "python-sip"


### PR DESCRIPTION
Note:
Not using "inherit ros", but FILES_${PN}-dev - seems cleaner for a package in recipe-extended (i.e. ros independent). Also, inheriting ros causes errors for orocos-kdl, see https://github.com/bmwcarit/meta-ros/pull/181#commitcomment-4471339
Unfortunately, this also means I cannot refer to ROS_BPN - so "hardcoding" those instead in the FILES directives, and using an expression in kdl.inc. 
I could redefine the ROS_BPN (perhaps using another name) variable in kdl.inc, and use them in the recipes, if this is considered cleaner.
