### PR TITLE
fix #222 - empy-latest to empy-${PV}

### DIFF
--- a/recipes-devtools/python/python-empy_3.3.bb
+++ b/recipes-devtools/python/python-empy_3.3.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=7fbc338309ac38fefcd64b04bb903e34"
 SRCNAME = "empy"
 
-SRC_URI = "http://www.alcyone.com/software/empy/empy-latest.tar.gz"
+SRC_URI = "http://www.alcyone.com/software/empy/empy-${PV}.tar.gz"
 SRC_URI[md5sum] = "e7b518a6fc4fd28fef87726cdb003118"
 SRC_URI[sha256sum] = "c625436d03cff8adbbade639d14a2df9bc4c4de99ec3a821ad4d6eeb66ade805"
 


### PR DESCRIPTION
Fix #222 - Change empy-latest.tar.gz to empy-${PV}.tar.gz

https://github.com/bmwcarit/meta-ros/issues/222
