### PR TITLE
rosserial-python: adding missing run dependencies

### DIFF
--- a/recipes-ros/rosserial/rosserial-python_0.5.5.bb
+++ b/recipes-ros/rosserial/rosserial-python_0.5.5.bb
@@ -4,3 +4,5 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 require rosserial.inc
+
+RDEPENDS_${PN} = "rosserial-msgs diagnostic-msgs"


### PR DESCRIPTION
Resolves following import errors in rosserial_python/SerialClient.py:
-ImportError: No module named rosserial_msgs.msg
-ImportError: No module named diagnostic_msgs.msg
