### PR TITLE
adding Upstream-Status to patches in recipes-ros

### DIFF
--- a/recipes-ros/actionlib/actionlib/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/actionlib/actionlib/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:00:25 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Backport [Accepted in indigo-devel branch]
 ---
  CMakeLists.txt | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-ros/catkin/catkin/0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch
+++ b/recipes-ros/catkin/catkin/0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch
@@ -3,6 +3,8 @@ From: Stefan Herbrechtsmeier <stefan@herbrechtsmeier.net>
 Date: Wed, 13 Mar 2013 11:49:17 +0100
 Subject: [PATCH] CATKIN_WORKSPACES: Don't require .catkin file
 
+Upstream-Status: Inappropriate [only for our setup]
+
 Signed-off-by: Stefan Herbrechtsmeier <stefan@herbrechtsmeier.net>
 ---
  cmake/all.cmake                            |    8 +++-----

--- a/recipes-ros/cmake-modules/cmake-modules/0001-Fix-the-path-added-to-CMAKE_MODULE_PATH.patch
+++ b/recipes-ros/cmake-modules/cmake-modules/0001-Fix-the-path-added-to-CMAKE_MODULE_PATH.patch
@@ -5,6 +5,8 @@ Subject: [PATCH] Fix the path added to CMAKE_MODULE_PATH.
 
 @CMAKE_INSTALL_PREFIX@/@CATKIN_PACKAGE_SHARE_DESTINATION@ have been
 replaced with "${cmake_modules_DIR}/.." to make the module work.
+
+Upstream-Status: Pending
 ---
  cmake/cmake_modules-extras.cmake.installspace.in |    2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan/0001-check-for-CATKIN_ENABLE_TESTING.patch
+++ b/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan/0001-check-for-CATKIN_ENABLE_TESTING.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Wed, 22 Jan 2014 11:18:25 +0100
 Subject: [PATCH] check for CATKIN_ENABLE_TESTING
 
+Upstream-Status: Accepted
 ---
  CMakeLists.txt | 8 +++++---
  package.xml    | 2 +-

--- a/recipes-ros/filters/filters/0001-check-for-CATKIN_ENABLE_TESTING.patch
+++ b/recipes-ros/filters/filters/0001-check-for-CATKIN_ENABLE_TESTING.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Sat, 12 Oct 2013 11:39:36 +0200
 Subject: [PATCH] check for CATKIN_ENABLE_TESTING
 
+Upstream-Status: Accepted
 ---
  CMakeLists.txt | 64 +++++++++++++++++++++++++++++++---------------------------
  package.xml    |  2 +-

--- a/recipes-ros/filters/filters/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/filters/filters/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:02:09 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Accepted
 ---
  CMakeLists.txt | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-ros/geometry-angles-utils/angles/0001-check-for-CATKIN_ENABLE_TESTING.patch
+++ b/recipes-ros/geometry-angles-utils/angles/0001-check-for-CATKIN_ENABLE_TESTING.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Mon, 15 Jul 2013 14:04:43 +0200
 Subject: [PATCH] check for CATKIN_ENABLE_TESTING
 
+Upstream-Status: Accepted
 ---
  angles/CMakeLists.txt | 4 +++-
  angles/package.xml    | 2 +-

--- a/recipes-ros/geometry/tf/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/geometry/tf/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:02:48 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Backport [Accepted in indigo-devel branch]
 ---
  tf/CMakeLists.txt | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

--- a/recipes-ros/image-common/camera-info-manager/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/image-common/camera-info-manager/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:04:23 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Accepted
 ---
  camera_info_manager/CMakeLists.txt | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-ros/navigation/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/navigation/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:05:31 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Submitted
 ---
  map_server/CMakeLists.txt     | 2 +-
  robot_pose_ekf/CMakeLists.txt | 3 ++-

--- a/recipes-ros/ros-comm/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/ros-comm/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,10 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 12:57:23 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+This patch includes the subsequent fix in the indigo-devel branch of the
+ros_comm repository (commit "fix find_package() call with two package names").
+
+Upstream-Status: Backport [Accepted in indigo-devel branch]
 ---
  tools/rosnode/CMakeLists.txt     | 3 ++-
  tools/rostopic/CMakeLists.txt    | 3 ++-
@@ -62,7 +66,8 @@ index e441b9a..2d52451 100644
  
  #Testing
  if(CATKIN_ENABLE_TESTING)
-+  find_package(rostest rosunit)
++  find_package(rostest)
++  find_package(rosunit)
    catkin_add_gtest(${PROJECT_NAME}-utest test/utest.cpp)
    if(TARGET ${PROJECT_NAME}-utest)
      target_link_libraries(${PROJECT_NAME}-utest topic_tools)

--- a/recipes-ros/ros-comm/roslaunch/0001-increase-rosmaster-timeout.patch
+++ b/recipes-ros/ros-comm/roslaunch/0001-increase-rosmaster-timeout.patch
@@ -6,6 +6,8 @@ Subject: Increase start and stop timeouts for ROS master.
 Certain boards are too slow to boot up the ROS master before roscore gives up.
 This patch increases the start and stop timeouts, giving the ROS master more
 time to start.
+
+Upstream-Status: Inappropriate [embedded specific]
 ---
  src/roslaunch/launch.py |    4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/recipes-ros/ros-control/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/ros-control/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:06:33 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Submitted
 ---
  controller_manager_tests/CMakeLists.txt | 3 ++-
  joint_limits_interface/CMakeLists.txt   | 3 ++-

--- a/recipes-ros/ros-controllers/joint-trajectory-controller/0001-check-for-CATKIN_ENABLE_TESTING.patch
+++ b/recipes-ros/ros-controllers/joint-trajectory-controller/0001-check-for-CATKIN_ENABLE_TESTING.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Thu, 10 Apr 2014 07:31:32 +0200
 Subject: [PATCH] check for CATKIN_ENABLE_TESTING
 
+Upstream-Status: Submitted
 ---
  joint_trajectory_controller/CMakeLists.txt | 44 ++++++++++++++++--------------
  joint_trajectory_controller/package.xml    |  2 +-

--- a/recipes-ros/ros-tutorials/rospy-tutorials/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/ros-tutorials/rospy-tutorials/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Tue, 4 Feb 2014 16:07:10 +0100
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
+Upstream-Status: Submitted
 ---
  rospy_tutorials/CMakeLists.txt | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-ros/xacro/xacro/0001-check-for-CATKIN_ENABLE_TESTING.patch
+++ b/recipes-ros/xacro/xacro/0001-check-for-CATKIN_ENABLE_TESTING.patch
@@ -3,6 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
 Date: Sat, 12 Oct 2013 11:14:26 +0200
 Subject: [PATCH] check for CATKIN_ENABLE_TESTING
 
+Upstream-Status: Accepted
 ---
  CMakeLists.txt | 6 ++++--
  package.xml    | 2 +-


### PR DESCRIPTION
This commit further adds a simple fix to the patch for the ros-comm
repository.
