### PR TITLE
log4cxx: keeping in-source build (resolves #252)

### DIFF
--- a/classes/autotools-brokensep.bbclass
+++ b/classes/autotools-brokensep.bbclass
@@ -1,0 +1,5 @@
+# Autotools class for recipes where separate build dir doesn't work
+# Ideally we should fix software so it does work. Standard autotools supports
+# this.
+inherit autotools
+B = "${S}"

--- a/recipes-devtools/log4cxx/log4cxx_0.10.0.bb
+++ b/recipes-devtools/log4cxx/log4cxx_0.10.0.bb
@@ -15,6 +15,6 @@ SRC_URI[sha256sum] = "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c
 
 S = "${WORKDIR}/apache-${BP}"
 
-inherit autotools pkgconfig
+inherit autotools-brokensep pkgconfig
 
 BBCLASSEXTEND += "native"


### PR DESCRIPTION
Adding 'B = ${S}' is preferred over using the autotools-brokensep
class. Using the autotools-brokensep is only backwards compatible
down to the openembedded-core commit 006b8a78 [1], whereas this
change is backwards compatible to even earlier versions.
This change works with openembedded-core commit f5bc3cfa [2], and
I expect it to work with even much more earlier versions.

[1] http://cgit.openembedded.org/openembedded-core/commit/?id=006b8a7808a58713af16c326dc37d07765334b12
[2] http://cgit.openembedded.org/openembedded-core/commit/?id=f5bc3cfac9545c402b415695c4e0f98ad38fb2b0
