### PR TITLE
roslaunch: removed ros-set-cmake-prefix dependency

### DIFF
--- a/recipes-ros/ros-comm/roslaunch/roscore.service
+++ b/recipes-ros/ros-comm/roslaunch/roscore.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Launcher for the ROS master, parameter server and rosout logging node
-After=network.target ros-set-cmake-prefix
+After=network.target
 
 [Service]
 EnvironmentFile=/etc/default/roscore


### PR DESCRIPTION
This branch removes the ros-set-cmake-prefix dependency, which I forgot to drop in the roscore.service systemd unit.
