### PR TITLE
libpoco: use system libraries instead of bundled versions

### DIFF
--- a/recipes-extended/libpoco/libpoco_1.5.2.bb
+++ b/recipes-extended/libpoco/libpoco_1.5.2.bb
@@ -13,6 +13,6 @@ SRC_URI += "file://0001-correct-path-for-CONFIGURE_FILE-in-CMakeLists.txt.patch"
 
 S = "${WORKDIR}/poco-poco-${PV}-release"
 
-EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release -DPOCO_UNBUNDLED=On"
 
 inherit cmake


### PR DESCRIPTION
Poco comes with bundled versions of SQLite3, zlib, expat, etc.

Adding the `-DPOCO_UNBUNDLED=On` option to CMake makes it use the ones provided by OE.
