### PR TITLE
some improvements to the speech-tools recipe

### DIFF
--- a/recipes-extended/speech-tools/speech-tools_2.3.bb
+++ b/recipes-extended/speech-tools/speech-tools_2.3.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "The Edinburgh Speech Tools Library"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://README;md5=9fe1b4db906b7d75f821c72a358638fd"
 
-DEPENDS = "alsa-lib"
+DEPENDS = "alsa-lib ncurses"
 
 SRC_URI = "http://tts.speech.cs.cmu.edu/awb/20130703/speech_tools-${PV}-current.tar.gz"
 SRC_URI[md5sum] = "02863b3ead04a0ade65982a1f34a60bb"

--- a/recipes-extended/speech-tools/speech-tools_2.3.bb
+++ b/recipes-extended/speech-tools/speech-tools_2.3.bb
@@ -10,7 +10,7 @@ SRC_URI[sha256sum] = "75e203402483b78de635943671aaf6f86cb6f9bf181fc84a931c2a560a
 
 S = "${WORKDIR}/speech_tools"
 
-inherit autotools
+inherit autotools-brokensep
 
 do_configure_prepend() { 
     #force crosscompilation compiler


### PR DESCRIPTION
The speech-tools recipe is improved, but the issue #278 still remains unresolved. speech-tools only builds when running `bitbake speech-tools` twice.
