### PR TITLE
Add eigen-conversions as a dependency to image-rotations

### DIFF
--- a/recipes-ros/image-pipeline/image-rotate_1.11.10.bb
+++ b/recipes-ros/image-pipeline/image-rotate_1.11.10.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=26;endline=26;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport opencv roscpp tf tf-conversions"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport opencv roscpp tf tf-conversions eigen-conversions"
 
 require image-pipeline.inc


### PR DESCRIPTION
I got the following error while building an image with packagegroup-ros-world included

```
| DEBUG: Executing shell function do_configure
| NOTE: cmake.bbclass no longer uses OECMAKE_SOURCEPATH and OECMAKE_BUILDPATH.  The default behaviour is now out-of-tree builds with B=WORKDIR/build.
| -- The C compiler identification is GNU 4.8.2
| -- The CXX compiler identification is GNU 4.8.2
| -- Check for working C compiler: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/bin/cortexa9hf-vfp-neon-poky-linux-gnueabi/arm-poky-linux-gnueabi-gcc
| -- Check for working C compiler: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/bin/cortexa9hf-vfp-neon-poky-linux-gnueabi/arm-poky-linux-gnueabi-gcc -- works
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Check for working CXX compiler: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/bin/cortexa9hf-vfp-neon-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++
| -- Check for working CXX compiler: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/bin/cortexa9hf-vfp-neon-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++ -- works
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Using CATKIN_DEVEL_PREFIX: /media/andy/Data/udoo_ros/build/tmp/work/cortexa9hf-vfp-neon-poky-linux-gnueabi/image-rotate/1.11.10-r0/build/devel
| -- Using CMAKE_PREFIX_PATH: /media/andy/Data/udoo_ros/build/tmp/sysroots/udoo-quad/usr;/media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr
| -- This workspace overlays: /media/andy/Data/udoo_ros/build/tmp/sysroots/udoo-quad/usr;/media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr
| -- Found PythonInterp: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/bin/python-native/python (found version "2.7.3")
| -- Using PYTHON_EXECUTABLE: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/bin/python-native/python
| -- Python version: 2.7
| -- Using default Python package layout
| -- Found PY_em: /media/andy/Data/udoo_ros/build/tmp/sysroots/x86_64-linux/usr/lib/python2.7/site-packages/em.pyc
| -- Using CATKIN_ENABLE_TESTING: 0
| -- catkin 0.5.88
| -- Using these message generators: gencpp;genlisp;genpy
| CMake Error at /media/andy/Data/udoo_ros/build/tmp/sysroots/udoo-quad/usr/share/catkin/cmake/catkinConfig.cmake:75 (find_package):
|   Could not find a package configuration file provided by "eigen_conversions"
|   with any of the following names:
| 
|     eigen_conversionsConfig.cmake
|     eigen_conversions-config.cmake
| 
|   Add the installation prefix of "eigen_conversions" to CMAKE_PREFIX_PATH or
|   set "eigen_conversions_DIR" to a directory containing one of the above
|   files.  If "eigen_conversions" provides a separate development package or
|   SDK, be sure it has been installed.
| Call Stack (most recent call first):
|   CMakeLists.txt:4 (find_package)
| 
| 
| -- Configuring incomplete, errors occurred!
```

Building eigen-conversions by hand and then resuming the image build fixed the problem, so it seems eigen-conversions was just missing in the dependencies.
