### PR TITLE
addressing obvious flaw in commit 53796fc4

### DIFF
--- a/recipes-ros/ros-comm/rosbag_1.10.10.bb
+++ b/recipes-ros/ros-comm/rosbag_1.10.10.bb
@@ -4,7 +4,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "boost cpp-common python-imaging rosbag-storage rosconsole roscpp roscpp-serialization
+DEPENDS = "boost cpp-common python-imaging rosbag-storage rosconsole roscpp roscpp-serialization \
     topic-tools xmlrpcpp"
 
 require ros-comm.inc


### PR DESCRIPTION
In commit 53796fc4, bitbake fails at parsing. It slipped through,
as I did not invoke any testing before submitting 53796fc4. This
commit resolves the obvious shortcoming.
