### PR TITLE
wxwidgets: keeping in-source build (resolves #299)

### DIFF
--- a/recipes-extended/wxwidgets/wxwidgets_2.9.5.bb
+++ b/recipes-extended/wxwidgets/wxwidgets_2.9.5.bb
@@ -12,7 +12,7 @@ SRC_URI[sha256sum] = "b74ba96ca537cc5d049d21ec9ab5eb2670406a4aa9f1ea4845ea84a995
 
 S = "${WORKDIR}/wxWidgets-${PV}"
 
-inherit autotools pkgconfig binconfig
+inherit autotools-brokensep pkgconfig binconfig
 
 EXTRA_AUTORECONF = " -I ${S}/build/aclocal"
 EXTRA_OECONF = "  --with-opengl \


### PR DESCRIPTION
This commit provides the autotools-brokensep class and uses it for the wxwidgets recipe.
The autotools-brokensep indicates that this package currently cannot handle out-of-source builds, and hence the in-source build must be kept until this is resolved.
The autotools-brokensep class is a copy of the autotools-brokensep class provided in the openembedded-core commit 006b8a78 [1].
To make this commit backwards compatible to even earlier versions of openembedded-core, we provide this class in meta-ros ourselves.

[1] http://cgit.openembedded.org/openembedded-core/commit?id=006b8a7808a58713af16c326dc37d07765334b12
