### PR TITLE
Fixed compile error

### DIFF
--- a/meta-ros2/recipes-devtools/python/python3-pymap3d_3.0.1.bb
+++ b/meta-ros2/recipes-devtools/python/python3-pymap3d_3.0.1.bb
@@ -19,7 +19,6 @@ from setuptools import setup
 setup(
        name="${PYPI_PACKAGE}",
        version="${PV}",
-       license="${LICENSE}",
 )
 EOF
 }


### PR DESCRIPTION
license string was appended in bbappend file was not properly processed. I remove license string in th setup.py when creating setup.py on the bbappend file.

https://github.com/dashingsoft/pyarmor/issues/1602 
https://stackoverflow.com/questions/77523055/missingdynamic-license-defined-outside-of-pyproject-toml-is-ignored

error message 

```
ERROR: python3-pymap3d-3.0.1-r0 do_compile: 'python3 setup.py bdist_wheel ' execution failed.
ERROR: python3-pymap3d-3.0.1-r0 do_compile: ExecutionError('/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/temp/run.do_compile.1195775', 1, None, None)
ERROR: Logfile of failure stored in: /home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/temp/log.do_compile.1195775
Log data follows:
| DEBUG: Executing shell function do_compile
| No `packages` or `py_modules` configuration, performing automatic discovery.
| `src-layout` detected -- analysing ./src
| discovered packages -- ['pymap3d', 'pymap3d.tests']
| discovered py_modules -- []
| /home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:76: _MissingDynamic: `license` defined outside of `pyproject.toml` is ignored.
| !!
|
|         ********************************************************************************
|         The following seems to be defined outside of `pyproject.toml`:
|
|         `license = 'BSD-2-Clause'`
|
|         According to the spec (see the link below), however, setuptools CANNOT
|         consider this value unless `license` is listed as `dynamic`.
|
|         https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table
|
|         To prevent this problem, you can list `license` under `dynamic` or alternatively
|         remove the `[project]` table from your file and rely entirely on other means of
|         configuration.
|         ********************************************************************************
|
| !!
|   _handle_missing_dynamic(dist, project_table)
| Traceback (most recent call last):
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/pymap3d-3.0.1/setup.py", line 3, in <module>
|     setup(
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/__init__.py", line 103, in setup
|     return distutils.core.setup(**attrs)
|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 159, in setup
|     dist.parse_config_files()
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/dist.py", line 627, in parse_config_files
|     pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py", line 68, in apply_configuration
|     return _apply(dist, config, filepath)
|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 57, in apply
|     _apply_project_table(dist, config, root_dir)
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 83, in _apply_project_table
|     corresp(dist, value, root_dir)
|   File "/home/bchoi/nvidia-yocto-bsp/bchoi-build/tmp/work/armv8a-oe4t-linux/python3-pymap3d/3.0.1/recipe-sysroot-native/usr/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 184, in _license
|     _set_config(dist, "license", val["text"])
|                                  ~~~^^^^^^^^
| KeyError: 'text'
| ERROR: 'python3 setup.py bdist_wheel ' execution failed.
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/bchoi/nvidia-yocto-bsp/layers/meta-ros/meta-ros2/recipes-devtools/python/python3-pymap3d_3.0.1.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 2062 tasks of which 2052 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/bchoi/nvidia-yocto-bsp/layers/meta-ros/meta-ros2/recipes-devtools/python/python3-pymap3d_3.0.1.bb:do_compile
Summary: There were 2 ERROR messages, returning a non-zero exit code.
bchoi@ubuntu-22:~/nvidia-yocto-bsp/bchoi-build$
```
