### PR TITLE
meta-ros-common: python3-pydot: Update branch to main

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python-pydot.inc
+++ b/meta-ros-common/recipes-devtools/python/python-pydot.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f5ce36373e1542c5b82d521315da8cc2"
 SRCNAME = "pydot"
 
 SRCREV = "979b0b7685c911fd8ef05feec1d3fe8c62e3247d"
-ROS_BRANCH ?= "branch=master"
+ROS_BRANCH ?= "branch=main"
 SRC_URI = "git://github.com/pydot/pydot;${ROS_BRANCH};protocol=https"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The 'master' branch appears to no longer be present on github, switch to 'main'.