### PR TITLE
[build] kas: added the meta-zenoh Yocto layer

### DIFF
--- a/kas/ros2/jazzy.yml
+++ b/kas/ros2/jazzy.yml
@@ -12,5 +12,11 @@ repos:
       meta-ros2:
       meta-ros2-jazzy:
 
+  zenoh:
+    url: "https://github.com/Jarsop/meta-zenoh.git"
+    path: "layers/meta-zenoh"
+    layers:
+      meta-zenoh:
+
 target:
   - ros-image-core

--- a/kas/ros2/kilted.yml
+++ b/kas/ros2/kilted.yml
@@ -12,5 +12,11 @@ repos:
       meta-ros2:
       meta-ros2-kilted:
 
+  zenoh:
+    url: "https://github.com/Jarsop/meta-zenoh.git"
+    path: "layers/meta-zenoh"
+    layers:
+      meta-zenoh:
+
 target:
   - ros-image-core

--- a/kas/ros2/rolling.yml
+++ b/kas/ros2/rolling.yml
@@ -12,5 +12,11 @@ repos:
       meta-ros2:
       meta-ros2-rolling:
 
+  zenoh:
+    url: "https://github.com/Jarsop/meta-zenoh.git"
+    path: "layers/meta-zenoh"
+    layers:
+      meta-zenoh:
+
 target:
   - ros-image-core


### PR DESCRIPTION
For rolling, kilted & jazzy

See: https://github.com/Jarsop/meta-zenoh.git

PS: only tested at master/rolling with `bitbake zenoh-c`