### PR TITLE
{common} add ROS desktop image

### DIFF
--- a/meta-ros-common/recipes-core/images/ros-image-desktop.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-desktop.bb
@@ -1,0 +1,12 @@
+require ${COREBASE}/meta/recipes-graphics/images/core-image-x11.bb
+
+SUMMARY = "Desktop image of ROS 2"
+DESCRIPTION = "The desktop variant provides all commonly used libraries as well as visualization tools and tutorials."
+HOMEPAGE = "https://www.ros.org/reps/rep-2001.html"
+
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+IMAGE_INSTALL:append = " \
+    desktop \
+"

--- a/meta-ros-common/recipes-core/images/ros-image-desktopfull.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-desktopfull.bb
@@ -1,0 +1,12 @@
+require ${COREBASE}/meta/recipes-graphics/images/core-image-x11.bb
+
+SUMMARY = "Desktop Full image of ROS 2"
+DESCRIPTION = "The desktop_full variant provides a "batteries included" experience, enabling novice users to complete most entry tutorials without knowledge of the underlying library structure."
+HOMEPAGE = "https://www.ros.org/reps/rep-2001.html"
+
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+IMAGE_INSTALL:append = " \
+    desktop-full \
+"


### PR DESCRIPTION
Add a Yocto image that includes `ros-core` and `desktop-full` with X11 support.

@robwoolley I assume this commit was buried set of patches.  Could this one be added?   