### PR TITLE
[build] kas menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bitbake-cookerdaemon.log
 .kas_shell_history
 build/
 layers/
+.config.yaml*

--- a/kas/Kconfig
+++ b/kas/Kconfig
@@ -1,0 +1,159 @@
+mainmenu "meta-ros Image configuration"
+
+menu "Yocto build options"
+
+	choice
+		prompt "Select machine"
+		default MACHINE_QEMUX86
+
+		config MACHINE_QEMUX86
+			bool "qemux86-64"
+
+		config MACHINE_RPI4
+			bool "raspberrypi4-64"
+
+		config MACHINE_RPI5
+			bool "raspberrypi5"
+	endchoice
+
+	choice
+		prompt "Select Yocto release"
+		default YOCTO_RELEASE_MASTER
+
+		config YOCTO_RELEASE_MASTER
+			bool "master"
+
+		config YOCTO_RELEASE_WALNASCAR
+			bool "walnascar"
+			help
+				5.2
+
+		config YOCTO_RELEASE_STYHEAD
+			bool "styhead"
+			help
+				5.1 (EOL)
+
+		config YOCTO_RELEASE_SCARTHGAP
+			bool "scarthgap"
+			help
+				5.0 LTS
+
+		config YOCTO_RELEASE_MICKLEDORE
+			bool "mickledore"
+			help
+				4.2 (EOL)
+
+		config YOCTO_RELEASE_KIRKSTONE
+			bool "kirkstone"
+			help
+			4.0 LTS
+
+	endchoice
+
+endmenu
+
+menu "ROS build options"
+	choice
+		prompt "Select ROS release"
+		default ROS_RELEASE_ROLLING
+
+		config ROS_RELEASE_ROLLING
+			bool "rolling"
+
+		config ROS_RELEASE_KILTED
+			bool "kilted"
+			help
+				ROS2 Kilted Kaiju
+
+		config ROS_RELEASE_JAZZY
+			bool "jazzy"
+			help
+				ROS2 Jazzy Jalisco
+
+		config ROS_RELEASE_HUMBLE
+			bool "humble"
+			help
+				ROS2 Humble Hawksbill
+
+		config ROS_RELEASE_NOETIC
+			bool "noetic"
+			help
+			ROS Noetic Ninjemys
+
+	endchoice
+
+endmenu
+
+menu "ROS image"
+	choice
+		prompt "Select ROS image"
+		default ROS_IMAGE_CORE
+
+		config ROS_IMAGE_CORE
+			bool "ros-image-core"
+
+		config ROS_IMAGE_WORLD
+			bool "ros-image-world"
+
+		config ROS_IMAGE_DESKTOP
+			bool "ros-image-desktop"
+
+		config ROS_IMAGE_DESKTOPFULL
+			bool "ros-image-desktopfull"
+	endchoice
+endmenu
+
+config KAS_TARGET_CHOICE
+       string
+	default "ros-image-core" if ROS_IMAGE_CORE
+	default "ros-image-world" if ROS_IMAGE_WORLD
+	default "ros-image-desktop" if ROS_IMAGE_DESKTOP
+	default "ros-image-desktopfull" if ROS_IMAGE_DESKTOPFULL
+
+config KAS_INCLUDE_YOCTO_RELEASE
+	string
+	default "kas/yocto/master.yml" if YOCTO_RELEASE_MASTER
+	default "kas/yocto/walnascar.yml" if YOCTO_RELEASE_WALNASCAR
+	default "kas/yocto/styhead.yml" if YOCTO_RELEASE_STYHEAD
+	default "kas/yocto/scarthgap.yml" if YOCTO_RELEASE_SCARTHGAP
+	default "kas/yocto/mickledore.yml" if YOCTO_RELEASE_MICKLEDORE
+	default "kas/yocto/kirkstone.yml" if YOCTO_RELEASE_KIRKSTONE
+
+config KAS_INCLUDE_ROS_RELEASE
+	string
+	default "kas/ros2/rolling.yml" if ROS_RELEASE_ROLLING
+	default "kas/ros2/kilted.yml" if ROS_RELEASE_KILTED
+	default "kas/ros2/jazzy.yml" if ROS_RELEASE_JAZZY
+	default "kas/ros2/humble.yml" if ROS_RELEASE_HUMBLE
+	default "kas/ros1/noetic.yml" if ROS_RELEASE_NOETIC
+
+config KAS_INCLUDE_MACHINE
+	string
+	default "kas/machine/qemux86-64.yml" if MACHINE_QEMUX86
+	default "kas/machine/raspberrypi4-64.yml" if MACHINE_RPI4
+	default "kas/machine/raspberrypi5.yml" if MACHINE_RPI5
+
+
+config KAS_INCLUDE_COMMON
+	string
+	default "kas/common.yml"
+
+config KAS_INCLUDE_SYSTEMD
+	string
+	default "kas/systemd.yml"
+
+config KAS_INCLUDE_VISIALIZATION
+	string
+	default "kas/visualization.yml"
+	depends on ROS_IMAGE_DESKTOP || ROS_IMAGE_DESKTOPFULL
+
+config KAS_MACHINE
+	string
+	default "qemux86-64" if MACHINE_QEMUX86
+	default "raspberrypi4-64" if MACHINE_RPI4
+	default "raspberrypi5" if MACHINE_RPI5
+
+config KAS_DISTRO
+	string
+	default "ros1" if ROS_RELEASE_NOETIC
+	default "ros2"

--- a/kas/common.yml
+++ b/kas/common.yml
@@ -1,5 +1,7 @@
 header:
   version: 14
+  includes:
+    - kas/layer/zenoh.yml
 
 local_conf_header:
   common: |

--- a/kas/common.yml
+++ b/kas/common.yml
@@ -2,6 +2,7 @@ header:
   version: 14
   includes:
     - kas/layer/zenoh.yml
+    - kas/layer/python-ai.yml
 
 local_conf_header:
   common: |

--- a/kas/layer/python-ai.yml
+++ b/kas/layer/python-ai.yml
@@ -1,0 +1,14 @@
+header:
+  version: 14
+
+repos:
+  python-ai:
+    url: "https://github.com/zboszor/meta-python-ai"
+    path: "layers/meta-python-ai"
+
+local_conf_header:
+  python-ai: |
+    FORTRAN:forcevariable = ",fortran"
+    RUNTIMETARGET:append:pn-gcc-runtime = " libquadmath"
+    HOSTTOOLS += "gfortran"
+    # TOOLCHAIN_TARGET_TASK:append = " gfortran"

--- a/kas/layer/zenoh.yml
+++ b/kas/layer/zenoh.yml
@@ -12,3 +12,4 @@ local_conf_header:
   zenoh: |
     ZENOH_SHARED_MEMORY = "true"
     ZENOH_UNSTABLE_API = "true"
+    INSANE_SKIP:pn-zenoh-c += "buildpaths"

--- a/kas/layer/zenoh.yml
+++ b/kas/layer/zenoh.yml
@@ -1,0 +1,14 @@
+header:
+  version: 14
+
+repos:
+  zenoh:
+    url: "https://github.com/Jarsop/meta-zenoh.git"
+    path: "layers/meta-zenoh"
+    layers:
+      meta-zenoh:
+
+local_conf_header:
+  zenoh: |
+    ZENOH_SHARED_MEMORY = "true"
+    ZENOH_UNSTABLE_API = "true"

--- a/kas/oeros-kirkstone-humble-jetson-agx-xavier-devkit.yml
+++ b/kas/oeros-kirkstone-humble-jetson-agx-xavier-devkit.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/humble.yml
     - kas/machine/jetson-agx-xavier-devkit.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-humble-jetson-orin-nano-devkit.yml
+++ b/kas/oeros-kirkstone-humble-jetson-orin-nano-devkit.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/humble.yml
     - kas/machine/jetson-orin-nano-devkit.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-humble-qemux86-64.yml
+++ b/kas/oeros-kirkstone-humble-qemux86-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/humble.yml
     - kas/machine/qemux86-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-humble-raspberrypi4-64.yml
+++ b/kas/oeros-kirkstone-humble-raspberrypi4-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/humble.yml
     - kas/machine/raspberrypi4-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-humble-raspberrypi5.yml
+++ b/kas/oeros-kirkstone-humble-raspberrypi5.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/humble.yml
     - kas/machine/raspberrypi5.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-jazzy-polarfire-soc-icicle-kit-es.yml
+++ b/kas/oeros-kirkstone-jazzy-polarfire-soc-icicle-kit-es.yml
@@ -10,3 +10,6 @@ header:
 repos:
   polarfire:
     branch: "master"
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-jazzy-qemux86-64.yml
+++ b/kas/oeros-kirkstone-jazzy-qemux86-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/jazzy.yml
     - kas/machine/qemux86-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-jazzy-raspberrypi4-64.yml
+++ b/kas/oeros-kirkstone-jazzy-raspberrypi4-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/jazzy.yml
     - kas/machine/raspberrypi4-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-jazzy-raspberrypi5.yml
+++ b/kas/oeros-kirkstone-jazzy-raspberrypi5.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/jazzy.yml
     - kas/machine/raspberrypi5.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-kilted-raspberrypi5.yml
+++ b/kas/oeros-kirkstone-kilted-raspberrypi5.yml
@@ -9,3 +9,6 @@ header:
 repos:
   raspberrypi:
     branch: "kirkstone"
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-noetic-qemux86-64.yml
+++ b/kas/oeros-kirkstone-noetic-qemux86-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros1/noetic.yml
     - kas/machine/qemux86-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-noetic-raspberrypi4-64.yml
+++ b/kas/oeros-kirkstone-noetic-raspberrypi4-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros1/noetic.yml
     - kas/machine/raspberrypi4-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-noetic-raspberrypi5.yml
+++ b/kas/oeros-kirkstone-noetic-raspberrypi5.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros1/noetic.yml
     - kas/machine/raspberrypi5.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-rolling-qemux86-64.yml
+++ b/kas/oeros-kirkstone-rolling-qemux86-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/rolling.yml
     - kas/machine/qemux86-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-rolling-raspberrypi4-64.yml
+++ b/kas/oeros-kirkstone-rolling-raspberrypi4-64.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/rolling.yml
     - kas/machine/raspberrypi4-64.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/oeros-kirkstone-rolling-raspberrypi5.yml
+++ b/kas/oeros-kirkstone-rolling-raspberrypi5.yml
@@ -5,3 +5,8 @@ header:
     - kas/ros2/rolling.yml
     - kas/machine/raspberrypi5.yml
     - kas/common.yml
+
+repos:
+  zenoh:
+    layers:
+      meta-zenoh: "disabled"

--- a/kas/visualization.yml
+++ b/kas/visualization.yml
@@ -18,3 +18,14 @@ local_conf_header:
     PACKAGECONFIG:append:pn-python3 = "  tk"
     PACKAGECONFIG:append:pn-mesa = " glvnd "
     LICENSE_FLAGS_ACCEPTED += "commercial"
+
+    # This is copied from default-providers.inc in oe-core
+    # It is being duplicated in local.conf to avoid being
+    # incorrectly overridden by in meta-raspberrypi
+    PREFERRED_PROVIDER_virtual/egl ?= "${@bb.utils.contains('DISTRO_FEATURES','glvnd','libglvnd','mesa',d)}"
+    PREFERRED_PROVIDER_virtual/libgl ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"
+    PREFERRED_PROVIDER_virtual/libgl-native ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd-native', 'mesa-native',d)}"
+    PREFERRED_PROVIDER_virtual/nativesdk-libgl ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'nativesdk-libglvnd', 'nativesdk-mesa',d)}"
+    PREFERRED_PROVIDER_virtual/libgles1 ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"
+    PREFERRED_PROVIDER_virtual/libgles2 ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"
+    PREFERRED_PROVIDER_virtual/libgles3 ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"

--- a/kas/visualization.yml
+++ b/kas/visualization.yml
@@ -12,20 +12,8 @@ repos:
 
 local_conf_header:
   world: |
-    DISTRO_FEATURES:append = " x11 opengl vulkan polkit glvnd"
+    DISTRO_FEATURES:append = " x11 opengl vulkan polkit"
     PACKAGECONFIG:append:pn-clang = "  libomp"
     PACKAGECONFIG:append:pn-qtbase-native = " gui"
     PACKAGECONFIG:append:pn-python3 = "  tk"
-    PACKAGECONFIG:append:pn-mesa = " glvnd "
     LICENSE_FLAGS_ACCEPTED += "commercial"
-
-    # This is copied from default-providers.inc in oe-core
-    # It is being duplicated in local.conf to avoid being
-    # incorrectly overridden by in meta-raspberrypi
-    PREFERRED_PROVIDER_virtual/egl ?= "${@bb.utils.contains('DISTRO_FEATURES','glvnd','libglvnd','mesa',d)}"
-    PREFERRED_PROVIDER_virtual/libgl ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"
-    PREFERRED_PROVIDER_virtual/libgl-native ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd-native', 'mesa-native',d)}"
-    PREFERRED_PROVIDER_virtual/nativesdk-libgl ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'nativesdk-libglvnd', 'nativesdk-mesa',d)}"
-    PREFERRED_PROVIDER_virtual/libgles1 ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"
-    PREFERRED_PROVIDER_virtual/libgles2 ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"
-    PREFERRED_PROVIDER_virtual/libgles3 ?= "${@bb.utils.contains('DISTRO_FEATURES', 'glvnd', 'libglvnd', 'mesa',d)}"

--- a/kas/yocto/kirkstone.yml
+++ b/kas/yocto/kirkstone.yml
@@ -5,11 +5,11 @@ defaults:
   repos:
     branch: "kirkstone"
 
-# https://downloads.yoctoproject.org/releases/yocto/yocto-4.0.27/RELEASENOTES
+# https://downloads.yoctoproject.org/releases/yocto/yocto-4.0.28/RELEASENOTES
 repos:
   openembedded-core:
     url: "https://github.com/openembedded/openembedded-core.git"
-    commit: "e8be08a624b2d024715a5c8b0c37f2345a02336b"
+    commit: "75e54301c5076eb0454aee33c870adf078f563fd"
     path: "layers/openembedded-core"
     layers:
       meta:
@@ -24,7 +24,7 @@ repos:
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    commit: "45bddd258a3d1ded925faf8389e01bb948dc7f5b"
+    commit: "058249f9a836e3aa866436aa6e37d6d48ff768fd"
     path: "layers/meta-openembedded"
     layers:
       meta-filesystems:

--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -32,3 +32,6 @@ repos:
       meta-python:
       meta-webserver:
       meta-xfce:
+
+  python-ai:
+    branch: "main"

--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -34,4 +34,4 @@ repos:
       meta-xfce:
 
   python-ai:
-    branch: "main"
+    branch: "master"

--- a/kas/yocto/scarthgap.yml
+++ b/kas/yocto/scarthgap.yml
@@ -5,11 +5,11 @@ defaults:
   repos:
     branch: "scarthgap"
 
-# https://downloads.yoctoproject.org/releases/yocto/yocto-5.0.10/RELEASENOTES
+# https://downloads.yoctoproject.org/releases/yocto/yocto-5.0.11/RELEASENOTES
 repos:
   openembedded-core:
     url: "https://github.com/openembedded/openembedded-core.git"
-    commit: "d5342ffc570d47a723b18297d75bd2f63c2088db"
+    commit: "7a59dc5ee6edd9596e87c2fbcd1f2594c06b3d1b"
     path: "layers/openembedded-core"
     layers:
       meta:
@@ -17,14 +17,14 @@ repos:
   bitbake:
     url: "https://github.com/openembedded/bitbake.git"
     branch: "2.8"
-    commit: "696c2c1ef095f8b11c7d2eff36fae50f58c62e5e"
+    commit: "139f61fe9eec221745184a14b3618d2dfa650b91"
     path: "layers/bitbake"
     layers:
       bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    commit: "727811eaf256b88fd135be99559f2cbf14c82fce"
+    commit: "e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943"
     path: "layers/meta-openembedded"
     layers:
       meta-filesystems:

--- a/kas/yocto/walnascar.yml
+++ b/kas/yocto/walnascar.yml
@@ -38,6 +38,10 @@ repos:
       meta-webserver:
       meta-xfce:
 
+  zenoh:
+    branch: "master"
+    commit: "207e9cb6b8c03308882e000ddeabf51b4fd11205"
+
 local_conf_header:
   distro: |
     ERROR_QA:remove = "license-exists"

--- a/kas/yocto/walnascar.yml
+++ b/kas/yocto/walnascar.yml
@@ -5,11 +5,11 @@ defaults:
   repos:
     branch: "walnascar"
 
-# https://downloads.yoctoproject.org/releases/yocto/yocto-5.2.1/RELEASENOTES
+# https://downloads.yoctoproject.org/releases/yocto/yocto-5.2.2/RELEASENOTES
 repos:
   openembedded-core:
     url: "https://github.com/openembedded/openembedded-core.git"
-    commit: "17affdaa600896282e07fb4d64cb23195673baa1"
+    commit: "c855be07828c9cff3aa7ddfa04eb0c4df28658e4"
     path: "layers/openembedded-core"
     layers:
       meta:
@@ -17,14 +17,14 @@ repos:
   bitbake:
     url: "https://github.com/openembedded/bitbake.git"
     branch: "2.12"
-    commit: "5b4e20377eea8d428edf1aeb2187c18f82ca6757"
+    commit: "74c28e14a9b5e2ff908a03f93c189efa6f56b0ca"
     path: "layers/bitbake"
     layers:
       bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    commit: "3c6844219a69d9ca8cb0f1579114efe9a9e2a646"
+    commit: "c009244a045923a9dfc32d7f2996cb61629870f6"
     path: "layers/meta-openembedded"
     layers:
       meta-filesystems:


### PR DESCRIPTION
The Kas tool of Siemens does have a 'menuconfig' command.

```
kas menu kas/Kconfig
```

This will bring up a menu to select:
  - Yocto release
  - Machine selection (qemu86-64, raspberrypi4-64, raspberrypi5)
  - ROS release
  - image selection (core, world, desktop)
![Screenshot from 2025-07-06 10-14-38](https://github.com/user-attachments/assets/f06b5c9d-6128-4774-b222-8f3a465d4469)

It will write a `.config.yaml` file.

This file can be used as

```
kas build .config.yaml
```

More info: https://kas.readthedocs.io/en/latest/userguide/plugins.html#module-kas.plugins.menu