### PR TITLE
[master]{rolling} rmw-zenoh-cpp: fixed 'find_if' is not a member of 'std';

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/rmw-zenoh/rmw-zenoh-cpp/0001-Adding-inclue-algorithm-for-std-find_if.patch
+++ b/meta-ros2-rolling/recipes-bbappends/rmw-zenoh/rmw-zenoh-cpp/0001-Adding-inclue-algorithm-for-std-find_if.patch
@@ -1,0 +1,29 @@
+From 8658330096bf0eb70b41ac5f19d7059a8d055b8e Mon Sep 17 00:00:00 2001
+From: Jan Vermaete <jan.vermaete@gmail.com>
+Date: Fri, 25 Jul 2025 20:19:45 +0200
+Subject: [PATCH] Adding inclue algorithm for std::find_if
+
+src/detail/graph_cache.cpp:355:36: error: 'find_if' is not a member of 'std'; did you mean 'find'?
+
+Upstream-Status: Pending
+
+Signed-off-by: Jan Vermaete <jan.vermaete@gmail.com>
+---
+ src/detail/graph_cache.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/detail/graph_cache.cpp b/src/detail/graph_cache.cpp
+index fb30142..e406d2d 100644
+--- a/src/detail/graph_cache.cpp
++++ b/src/detail/graph_cache.cpp
+@@ -12,6 +12,7 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+ 
++#include <algorithm>
+ #include <array>
+ #include <functional>
+ #include <limits>
+-- 
+2.39.5
+

--- a/meta-ros2-rolling/recipes-bbappends/rmw-zenoh/rmw-zenoh-cpp_0.8.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/rmw-zenoh/rmw-zenoh-cpp_0.8.1-1.bbappend
@@ -1,5 +1,9 @@
 LICENSE = "Apache-2.0 & BSD-3-Clause"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Adding-inclue-algorithm-for-std-find_if.patch"
+
 ROS_BUILD_DEPENDS += "\
     rosidl-generator-c-native \
     rosidl-generator-cpp-native \


### PR DESCRIPTION
added a patch that is also upstreamed to fix a gcc 15.1 issue