### PR TITLE
[master]{common} ode: Allow to build with CMake 4+

### DIFF
--- a/meta-ros-common/recipes-support/ode/ode_0.16.5.bb
+++ b/meta-ros-common/recipes-support/ode/ode_0.16.5.bb
@@ -23,9 +23,10 @@ SRC_URI = "git://bitbucket.org/odedevs/ode.git;protocol=https;branch=0.16.x"
 PV = "0.16.5+git"
 SRCREV = "cc5ca0e9417a8cf4000a63a5346c96eba0f5610b"
 
-
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'opengl', d)}"
 PACKAGECONFIG[opengl] = "-DODE_WITH_DEMOS=ON,-DODE_WITH_DEMOS=OFF,virtual/libgl freeglut libx11"
 PACKAGECONFIG[ccd] = "-DODE_WITH_LIBCCD=ON,-DODE_WITH_LIBCCD=OFF,ccd"
+
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 inherit cmake


### PR DESCRIPTION
| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.