### PR TITLE
[master]{common} gz-fuel-tools: added version 10.1.0

### DIFF
--- a/meta-ros-common/recipes-devtools/gazebo/gz-fuel-tools10_10.1.0.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-fuel-tools10_10.1.0.bb
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a461be67a1edf991251f85f3aadd1d0"
+
+SRC_URI = "git://github.com/gazebosim/gz-fuel-tools;protocol=https;branch=gz-fuel-tools10"
+
+SRCREV = "dd5b306bde5ac0d38e28a39a1a631739bba7842e"
+
+inherit cmake
+
+DEPENDS = "\
+    gz-cmake4 \
+    gz-common6 \
+    gz-msgs11 \
+    jsoncpp \
+    libyaml \
+    libzip \
+    curl \
+"
+
+FILES:${PN} += "\
+    ${libdir}/ruby/gz/cmdfuel10.rb \
+    ${datadir}/gz/gz2.completion.d/fuel10.bash_completion.sh \
+    ${datadir}/gz/fuel10.yaml \
+    ${datadir}/gz/fuel_tools10/config.yaml \
+"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Needed for gz-fuel-tools-vendor [master]{rolling}

1. Migrate bazel build setup to use bzlmod
    * [Pull request #466](https://github.com/gazebosim/gz-fuel-tools/pull/466)
    * [Pull request #467](https://github.com/gazebosim/gz-fuel-tools/pull/467)

1. ci: run cppcheck, cpplint, doxygen on noble
    * [Pull request #462](https://github.com/gazebosim/gz-fuel-tools/pull/462)

1. Fix return value when download fails
    * [Pull request #459](https://github.com/gazebosim/gz-fuel-tools/pull/459)

1. Fix code documentation spelling (#458)
    * [Pull request #460](https://github.com/gazebosim/gz-fuel-tools/pull/460)