### PR TITLE
[kirkstone]{jazzy} shared-queues-vendor: fix bbappend

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/rosbag2/shared-queues-vendor/0001-CMakeLists.txt-fetch-readerwriterqueue-and-concurren.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/rosbag2/shared-queues-vendor/0001-CMakeLists.txt-fetch-readerwriterqueue-and-concurren.patch
@@ -4,18 +4,19 @@ Date: Fri, 27 Nov 2020 09:12:58 -0800
 Subject: [PATCH] CMakeLists.txt: fetch readerwriterqueue and concurrentqueue
  with bitbake fetcher
 
-Upstream-Status: Pending
+Upstream-Status: Inappropriate [oe specific]
 
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+Signed-off-by: Jan Vermaete <jan.vermaete@gmail.com>
 ---
- CMakeLists.txt | 20 ++++++--------------
- 1 file changed, 6 insertions(+), 14 deletions(-)
+ CMakeLists.txt | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0daf4672..465367f2 100644
+index 0c95c8bde..65ebdb5d3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -6,11 +6,7 @@ find_package(ament_cmake REQUIRED)
+@@ -11,11 +11,7 @@ endif()
  include(ExternalProject)
  # Single producer single consumer queue by moodycamel - header only, don't build, install
  ExternalProject_Add(ext-singleproducerconsumer
@@ -28,31 +29,16 @@ index 0daf4672..465367f2 100644
    INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
    CONFIGURE_COMMAND ""
    BUILD_COMMAND ""
-@@ -19,11 +15,7 @@ ExternalProject_Add(ext-singleproducerconsumer
- 
- # Concurrent and blocking concurrent queue by moodycamel - header only, don't build, install
- ExternalProject_Add(ext-concurrentqueue
--  PREFIX concurrentqueue
--  DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/download
--  URL https://github.com/cameron314/concurrentqueue/archive/8f65a8734d77c3cc00d74c0532efca872931d3ce.zip
--  URL_MD5 71a0d932cc89150c2ade85f0d9cac9dc
--  TIMEOUT 60
-+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/concurrentqueue-upstream
-   INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
-   CONFIGURE_COMMAND ""
-   BUILD_COMMAND ""
-@@ -45,10 +37,10 @@ install(
+@@ -34,8 +30,8 @@ install(
  # Install headers
  install(
    FILES
 -  "${CMAKE_CURRENT_BINARY_DIR}/singleproducerconsumer/src/ext-singleproducerconsumer/atomicops.h"
 -  "${CMAKE_CURRENT_BINARY_DIR}/singleproducerconsumer/src/ext-singleproducerconsumer/readerwriterqueue.h"
--  "${CMAKE_CURRENT_BINARY_DIR}/concurrentqueue/src/ext-concurrentqueue/concurrentqueue.h"
--  "${CMAKE_CURRENT_BINARY_DIR}/concurrentqueue/src/ext-concurrentqueue/blockingconcurrentqueue.h"
 +  "${PROJECT_SOURCE_DIR}/singleproducerconsumer-upstream/atomicops.h"
 +  "${PROJECT_SOURCE_DIR}/singleproducerconsumer-upstream/readerwriterqueue.h"
-+  "${PROJECT_SOURCE_DIR}/concurrentqueue-upstream/concurrentqueue.h"
-+  "${PROJECT_SOURCE_DIR}/concurrentqueue-upstream/blockingconcurrentqueue.h"
    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/moodycamel
  )
  
+-- 
+2.43.0

--- a/meta-ros2-jazzy/recipes-bbappends/rosbag2/shared-queues-vendor_0.26.7-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/rosbag2/shared-queues-vendor_0.26.7-1.bbappend
@@ -11,7 +11,7 @@ SRC_URI = " \
     git://github.com/cameron314/readerwriterqueue.git;protocol=https;name=singleproducerconsumer-upstream;destsuffix=git/singleproducerconsumer-upstream;branch=master \
     git://github.com/cameron314/concurrentqueue.git;protocol=https;name=concurrentqueue-upstream;destsuffix=git/concurrentqueue-upstream;branch=master \
 "
-SRCREV_release = "dc17fed08353f30a7e20676df7c8fc5e842ed011"
+SRCREV_release = "a900b3c1d2c0640da201040c516a486e665f801d"
 SRCREV_singleproducerconsumer-upstream = "ef7dfbf553288064347d51b8ac335f1ca489032a"
 SRCREV_concurrentqueue-upstream = "8f65a8734d77c3cc00d74c0532efca872931d3ce"
 


### PR DESCRIPTION
- fixed the upstream SRC_URI
- Update of the patch
Should fix https://github.com/ros/meta-ros/issues/1519