### PR TITLE
[walnascar]{noetic} Fixed Errors about QA Issue for noetic

### DIFF
--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/sensor-msgs_1.13.2-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/sensor-msgs_1.13.2-1.bbappend
@@ -6,3 +6,8 @@ LICENSE = "BSD-3-Clause"
 ROS_BUILDTOOL_DEPENDS += " \
     ${PYTHON_PN}-pyyaml-native \
 "
+
+# QA Issue: File /opt/ros/noetic/lib/python3.13/site-packages/sensor_msgs/__pycache__/__init__.cpython-313.pyc in package sensor-msgs contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}##g" ${D}${ros_prefix}/lib/python3.13/site-packages/sensor_msgs/__pycache__/__init__.cpython-313.pyc
+}

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/topic-tools_1.17.4-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/topic-tools_1.17.4-1.bbappend
@@ -1,3 +1,8 @@
 # Copyright (c) 2023 Wind River Systems, Inc.
 
 LICENSE = "BSD-3-Clause"
+
+# QA Issue: File /opt/ros/noetic/lib/python3.13/site-packages/topic_tools/__pycache__/__init__.cpython-313.pyc in package topic-tools contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}##g" ${D}${ros_prefix}/lib/python3.13/site-packages/topic_tools/__pycache__/__init__.cpython-313.pyc
+}


### PR DESCRIPTION
Fixed Errors about QA Issue with package topic-tools and sensor-msgs contains reference to TMPDIR [buildpaths]

Error log contains these two lines:

- QA Issue: File /opt/ros/noetic/lib/python3.13/site-packages/topic_tools/__pycache__/__init__.cpython-313.pyc in package topic-tools contains reference to TMPDIR [buildpaths]
- QA Issue: File /opt/ros/noetic/lib/python3.13/site-packages/sensor_msgs/__pycache__/__init__.cpython-313.pyc in package sensor-msgs contains reference to TMPDIR [buildpaths]

<img width="3838" height="788" alt="image" src="https://github.com/user-attachments/assets/cffaf154-85d4-4541-bcbd-99b69dcb74b3" />
