### PR TITLE
{common} rosdistro: version bump 0.8.3 -> 1.0.1 + nativesdk

### DIFF
--- a/meta-ros-common/recipes-infrastructure/python/python3-rosdistro_0.8.3.bb
+++ b/meta-ros-common/recipes-infrastructure/python/python3-rosdistro_0.8.3.bb
@@ -1,3 +1,0 @@
-require python-rosdistro.inc
-
-inherit setuptools3

--- a/meta-ros-common/recipes-infrastructure/python/python3-rosdistro_1.0.1.bb
+++ b/meta-ros-common/recipes-infrastructure/python/python3-rosdistro_1.0.1.bb
@@ -4,11 +4,13 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=988919d688133096537549f9afebf425"
 SRCNAME = "rosdistro"
 
-SRCREV = "221369488df68ffcaed8c7a53983fd5b3e52866d"
+inherit setuptools3
+
 ROS_BRANCH ?= "branch=master"
 SRC_URI = "git://github.com/ros-infrastructure/rosdistro;${ROS_BRANCH};protocol=https"
+SRCREV = "9c909bfb7f34e13e8229f1742b6493b228a3cfa9"
 
+RDEPENDS:${PN} += "python3-pyyaml"
 
-RDEPENDS:${PN} += "${PYTHON_PN}-pyyaml"
+BBCLASSEXTEND = "native nativesdk"
 
-BBCLASSEXTEND = "native"


### PR DESCRIPTION
* version bump to latest release
* removed old python2/python3 style
   - include removed of the inc file
* added nativesdk to BBCLASSEXTEND

@robwoolley This will be part of a few commit (I expect).  All related to be able to generated the ROS package documentation.  No need to apply yet.  A few patches in meta-openembedded have to be applied first.