### PR TITLE
[Scarthgap]{jazzy}{humble} Correct the licenses name of eigenpy and tl-expected

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-2.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-2.bbappend
@@ -1,0 +1,3 @@
+# Original license in package.xml, joined with "&" when multiple license tags were used:
+#         "Creative Commons Zero v1.0 Universal"
+LICENSE = "CC0-1.0"

--- a/meta-ros2-humble/recipes-bbappends/eigenpy/eigenpy_3.11.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/eigenpy/eigenpy_3.11.0-1.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2022 Wind River Systems, Inc.
 
+LICENSE = "BSD-2-Clause"
+
 ROS_BUILDTOOL_DEPENDS += "python3-numpy-native"
 
 inherit python3native

--- a/meta-ros2-jazzy/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-5.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-5.bbappend
@@ -1,0 +1,3 @@
+# Original license in package.xml, joined with "&" when multiple license tags were used:
+#         "Creative Commons Zero v1.0 Universal"
+LICENSE = "CC0-1.0"

--- a/meta-ros2-jazzy/recipes-bbappends/eigenpy/eigenpy_3.11.0-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/eigenpy/eigenpy_3.11.0-1.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2022 Wind River Systems, Inc.
 
+LICENSE = "BSD-2-Clause"
+
 ROS_BUILDTOOL_DEPENDS += "python3-numpy-native"
 
 inherit python3native


### PR DESCRIPTION
correct eigenpy's license to 'BSD-2-Clause'
correct tl-expected's license to 'CC0-1.0'