### PR TITLE
images: add the LICENSE variable and set it to MIT

### DIFF
--- a/meta-ros-common/recipes-core/images/ros-image-core.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-core.bb
@@ -2,6 +2,7 @@ require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
 
 SUMMARY = "A small image just capable of starting core ROS."
 DESCRIPTION = "${SUMMARY}"
+LICENSE = "MIT"
 
 inherit ros_distro_${ROS_DISTRO}
 inherit ${ROS_DISTRO_TYPE}_image

--- a/meta-ros-common/recipes-core/images/ros-image-turtlebot3-all.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-turtlebot3-all.bb
@@ -4,6 +4,7 @@ require ros-image-core.bb
 
 SUMMARY = "Core ROS image containing all TurtleBot 3 packages"
 DESCRIPTION = "${SUMMARY}"
+LICENSE = "MIT"
 
 IMAGE_INSTALL:append = " \
     packagegroup-ros-turtlebot3-core \

--- a/meta-ros-common/recipes-core/images/ros-image-turtlebot3-core.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-turtlebot3-core.bb
@@ -4,6 +4,7 @@ require ros-image-core.bb
 
 SUMMARY = "Core ROS image containing core TurtleBot 3 packages"
 DESCRIPTION = "${SUMMARY}"
+LICENSE = "MIT"
 
 IMAGE_INSTALL:append = " \
     packagegroup-ros-turtlebot3-core \

--- a/meta-ros-common/recipes-core/images/ros-image-world.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-world.bb
@@ -2,6 +2,7 @@ require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
 
 SUMMARY = "An image with packagegroup-ros-world installed"
 DESCRIPTION = "${SUMMARY}"
+LICENSE = "MIT"
 
 inherit ros_distro_${ROS_DISTRO}
 inherit ${ROS_DISTRO_TYPE}_image


### PR DESCRIPTION
@robwoolley I saw a discussion on one of the mailing lists some time ago if a image recipe needs to have a license.
I though the conclusion was it should have.  But the license is about the recipe, not the image.
I checked the most common images recipes of Yocto/OpenEmbedded and MIT seems to be the one that is common used for this.
Although I'm just proposing this, feel free to request a modification.

And it's fixing some oelint-adv issues too.

--
It's common that the image recipes also have a LICENSE variable.

See:
  commit fb617bed6ebbb17ca9a14ea5985302b03311ccb7
  Author: Richard Purdie <rpurdie@linux.intel.com>
  Date:   Tue Sep 7 18:03:51 2010 +0100

      poky-image: Set LICENSE field for the image recipes (note this doesn't apply to the image contents, just the recipe and code used

      Signed-off-by: Richard Purdie <rpurdie@linux.intel.com>
on git://git.yoctoproject.org/poky