### PR TITLE
[scarthgap]{jazzy}: rmw-zenoh: use system zenoh (zenohc/zenohcxx)

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/rmw-zenoh/rmw-zenoh-cpp_0.2.5-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/rmw-zenoh/rmw-zenoh-cpp_0.2.5-1.bbappend
@@ -1,0 +1,7 @@
+LICENSE = "Apache-2.0"
+
+ROS_BUILDTOOL_DEPENDS += " \
+    rosidl-generator-c-native \
+    rosidl-generator-cpp-native \
+    fastrtps-cmake-module-native \
+"

--- a/meta-ros2-jazzy/recipes-bbappends/rmw-zenoh/zenoh-cpp-vendor/use-system-zenoh.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/rmw-zenoh/zenoh-cpp-vendor/use-system-zenoh.patch
@@ -1,0 +1,49 @@
+From 8bcdcdb6dd43d74e43359fdb68b9c8f6443fd46b Mon Sep 17 00:00:00 2001
+From: Georg <georg.schmalhofer@gmail.com>
+Date: Sat, 27 Sep 2025 15:42:13 +0200
+Subject: [PATCH] Use system-provided zenoh packages
+
+---
+ CMakeLists.txt | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 18c92be..40ed094 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,6 +17,8 @@ find_package(ament_cmake_vendor_package REQUIRED)
+ # when expanded.
+ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memory zenoh/transport_compression zenoh/transport_tcp zenoh/transport_udp zenoh/transport_tls")
+ 
++find_package(zenohc)
++
+ # Set VCS_VERSION to 1.4.0 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+ # - Add a "bind" config option for endpoints:
+ #    - https://github.com/eclipse-zenoh/zenoh/pull/1892
+@@ -30,6 +32,7 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
+ # - Add support for DiffServ's DSCP config for endpoints:
+ #    - https://github.com/eclipse-zenoh/zenoh/pull/1937
+ ament_vendor(zenoh_c_vendor
++  SATISFIED zenohc_FOUND
+   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
+   VCS_VERSION 6bea1f1ebc29412548f36af91cf2225c8bf476d4
+   CMAKE_ARGS
+@@ -41,15 +44,16 @@ ament_vendor(zenoh_c_vendor
+ 
+ ament_export_dependencies(zenohc)
+ 
++find_package(zenohcxx)
++
+ ament_vendor(zenoh_cpp_vendor
++  SATISFIED zenoh_FOUND
+   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
+   VCS_VERSION 7379592436398079934f4296d2fa90217f8eddf9
+   CMAKE_ARGS
+     -DZENOHCXX_ZENOHC=OFF
+ )
+ 
+-externalproject_add_stepdependencies(zenoh_cpp_vendor configure zenoh_c_vendor)
+-
+ ament_export_dependencies(zenohcxx)
+ 
+ ament_package()

--- a/meta-ros2-jazzy/recipes-bbappends/rmw-zenoh/zenoh-cpp-vendor_0.2.5-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/rmw-zenoh/zenoh-cpp-vendor_0.2.5-1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://use-system-zenoh.patch"
+
+ROS_BUILD_DEPENDS += " zenoh-c zenoh-cpp"


### PR DESCRIPTION
Make rmw-zenoh use system-provided zenoh libraries and adjust dependencies. This mirrors the approach in meta-ros2-rolling, with the addition of fastrtps-cmake-module-native which appears required here.