### PR TITLE
{rolling}: replace ${PYTHON_PN} by python3

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/cartographer/cartographer_2.0.9004-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/cartographer/cartographer_2.0.9004-1.bbappend
@@ -15,7 +15,7 @@ inherit pkgconfig
 
 # This is used only to generate documentation so it should
 # be native and needs quite a lot of native python dependencies
-ROS_BUILD_DEPENDS:remove = "${PYTHON_PN}-sphinx python-sphinx"
+ROS_BUILD_DEPENDS:remove = "python3-sphinx python-sphinx"
 
 DEPENDS += "\
     protobuf-native \

--- a/meta-ros2-rolling/recipes-bbappends/ros2cli/ros2cli_0.40.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/ros2cli/ros2cli_0.40.1-1.bbappend
@@ -2,14 +2,14 @@
 
 # Needed to run ros2 commands on the target.
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-codecs \
-    ${PYTHON_PN}-debugger \
-    ${PYTHON_PN}-json \
-    ${PYTHON_PN}-misc \
-    ${PYTHON_PN}-netifaces \
-    ${PYTHON_PN}-pydoc \
-    ${PYTHON_PN}-pyparsing \
-    ${PYTHON_PN}-pyyaml \
-    ${PYTHON_PN}-xmlrpc \
+    python3-codecs \
+    python3-debugger \
+    python3-json \
+    python3-misc \
+    python3-netifaces \
+    python3-pydoc \
+    python3-pyparsing \
+    python3-pyyaml \
+    python3-xmlrpc \
     rosidl-generator-py \
 "

--- a/meta-ros2-rolling/recipes-bbappends/vision-opencv/cv-bridge_4.1.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/vision-opencv/cv-bridge_4.1.0-1.bbappend
@@ -6,7 +6,7 @@ ROS_BUILD_DEPENDS:remove = "python3-numpy"
 LICENSE = "Apache-2.0 & BSD-3-Clause"
 
 ROS_BUILDTOOL_DEPENDS += "\
-    ${PYTHON_PN}-numpy-native \
+    python3-numpy-native \
 "
 
 # QA Issue: File /opt/ros/rolling/share/cv_bridge/cmake/cv_bridge-extras.cmake in package cv-bridge-dev contains reference to TMPDIR [buildpaths]


### PR DESCRIPTION
see: https://docs.yoctoproject.org/singleindex.html#removed-variables

There are still some ${PYTHON_PN} strings in the generated bb files. This should be solved in rosdistro.

tested at rolling/master