### PR TITLE
[whinlatter]{common} Remove S = "${WORKDIR}/git" from recipes

### DIFF
--- a/meta-ros-common/recipes-devtools/coinor/coinor-cbc_git.bb
+++ b/meta-ros-common/recipes-devtools/coinor/coinor-cbc_git.bb
@@ -6,8 +6,6 @@ SRC_URI = "git://github.com/coin-or/Cbc.git;protocol=https;branch=master"
 PV = "2.10.12+git"
 SRCREV = "a5f28a33fc4ee170fe51b3706c0400660b3f2f65"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "coinor-buildtools-native coinutils coinor-osi coinor-cgl coinor-clp"
 
 inherit autotools pkgconfig

--- a/meta-ros-common/recipes-devtools/coinor/coinor-cgl_git.bb
+++ b/meta-ros-common/recipes-devtools/coinor/coinor-cgl_git.bb
@@ -8,7 +8,6 @@ SRCREV = "581c780d8fcda5e02f3c8ef2975bc6804555fa41"
 DEPENDS = "coinor-buildtools-native coinutils coinor-osi coinor-clp"
 
 PV = "0.60.9+git"
-S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 

--- a/meta-ros-common/recipes-devtools/coinor/coinor-clp_git.bb
+++ b/meta-ros-common/recipes-devtools/coinor/coinor-clp_git.bb
@@ -6,8 +6,6 @@ SRC_URI = "git://github.com/coin-or/Clp.git;protocol=https;branch=master"
 PV = "1.17.10+git"
 SRCREV = "e28045d7d35465c4880118538b050e5478e01fa3"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "coinor-buildtools-native coinutils coinor-osi"
 
 inherit autotools pkgconfig

--- a/meta-ros-common/recipes-devtools/coinor/coinor-osi_git.bb
+++ b/meta-ros-common/recipes-devtools/coinor/coinor-osi_git.bb
@@ -6,8 +6,6 @@ SRC_URI = "git://github.com/coin-or/Osi.git;protocol=https;branch=master"
 PV = "0.108.11+git"
 SRCREV = "cb16146c414843076e397370d051a168b7c9215d"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "coinor-buildtools-native coinutils"
 
 inherit autotools pkgconfig

--- a/meta-ros-common/recipes-devtools/coinor/coinutils_git.bb
+++ b/meta-ros-common/recipes-devtools/coinor/coinutils_git.bb
@@ -8,7 +8,6 @@ SRCREV = "ffd24f05c068ba84c84eb39de5bb308ed2dc3fb5"
 DEPENDS = "coinor-buildtools-native lapack"
 
 PV = "2.11.12+git"
-S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 

--- a/meta-ros-common/recipes-devtools/stress/stress_1.0.7.bb
+++ b/meta-ros-common/recipes-devtools/stress/stress_1.0.7.bb
@@ -5,6 +5,4 @@ SRC_URI = "git://github.com/resurrecting-open-source-projects/stress;protocol=ht
 
 SRCREV = "f725109e8b98260933fdca7cf8166e017311bac4"
 
-S = "${WORKDIR}/git"
-
 inherit autotools

--- a/meta-ros-common/recipes-extended/nanoflann/nanoflann_1.7.1.bb
+++ b/meta-ros-common/recipes-extended/nanoflann/nanoflann_1.7.1.bb
@@ -8,8 +8,6 @@ SRC_URI = "git://github.com/jlblancoc/nanoflann.git;protocol=https;branch=master
 PV = "1.7.1+git"
 SRCREV = "9a653cb243db6a09c94f833b28732b62f033e2b5"
 
-S = "${WORKDIR}/git"
-
 inherit cmake pkgconfig
 
 DEPENDS += "libeigen googletest"

--- a/meta-ros-common/recipes-graphics/xclip/xclip_0.13.bb
+++ b/meta-ros-common/recipes-graphics/xclip/xclip_0.13.bb
@@ -5,8 +5,6 @@ SRC_URI = "git://github.com/astrand/xclip;protocol=https;branch=master"
 
 SRCREV = "2c3b811002b35d3be7f39cc1145dd06bdb32e31c"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "libxmu libx11"
 
 inherit autotools-brokensep

--- a/meta-ros-common/recipes-multimedia/libcamera/libcamera_0.5.2.bb
+++ b/meta-ros-common/recipes-multimedia/libcamera/libcamera_0.5.2.bb
@@ -16,8 +16,6 @@ SRCREV = "aa0a91c48ddb38c302390d5c4899cb9e093ddd24"
 
 PE = "1"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "python3-pyyaml-native python3-jinja2-native python3-ply-native python3-jinja2-native udev gnutls chrpath-native libevent libyaml"
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'qt', 'qtbase qtbase-native', '', d)}"
 

--- a/meta-ros-common/recipes-support/openvdb/openvdb_10.0.1.bb
+++ b/meta-ros-common/recipes-support/openvdb/openvdb_10.0.1.bb
@@ -11,8 +11,6 @@ SRC_URI = "git://github.com/AcademySoftwareFoundation/openvdb.git;protocol=https
 
 SRCREV = "166946c0365b16da7b2114e37f1187ab5ecd0916"
 
-S = "${WORKDIR}/git"
-
 DEPENDS = "imath tbb log4cplus blosc zlib"
 
 inherit cmake pkgconfig


### PR DESCRIPTION
Yocto Whinlatter throws an error if a recipe sets S = "${WORKDIR}/git" since this is already set by bitbake.conf in oe-core:

```
ERROR: stress-1.0.7-r0 do_unpack: Recipes that set S = "${WORKDIR}/git" or S = "${UNPACKDIR}/git" should remove that assignment, as S set by bitbake.conf in oe-core now works.
```