### PR TITLE
{common} Add mash_generated.bbclass

### DIFF
--- a/meta-ros-common/classes/mash_generated.bbclass
+++ b/meta-ros-common/classes/mash_generated.bbclass
@@ -1,0 +1,11 @@
+# Inherited by every recipe that mash generates.
+#
+# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2025 Wind River Systems, Inc.
+
+MASH_GENERATED = "1"
+
+# If mash found this BPN listed as a build tool, extend the recipe to build BPN-native and BPN-nativesdk.
+BBCLASSEXTEND:append = "${@bb.utils.contains('MASH_GENERATED_BUILDTOOLS', '${BPN}-native', ' native nativesdk', '', d)}"
+
+inherit ros_component


### PR DESCRIPTION
Add a mash_generated.bbclass to support recipes built using the mash tool (https://github.com/robwoolley/mash)

Resolves issue: https://github.com/ros/meta-ros/issues/1615