### PR TITLE
Update pcl-ros_2.6.2-1.bbappend for TMPDIR

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/perception-pcl/pcl-ros_2.6.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/perception-pcl/pcl-ros_2.6.2-1.bbappend
@@ -4,5 +4,6 @@ LICENSE = "BSD-3-Clause"
 
 # QA Issue: File /opt/ros/rolling/share/pcl_ros/cmake/export_pcl_rosExport.cmake in package pcl-ros-dev contains reference to TMPDIR [buildpaths]
 do_install:append() {
-    sed -i -e "s#${RECIPE_SYSROOT}##g" ${D}${ros_datadir}/pcl_ros/cmake/export_pcl_rosExport.cmake
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g"  ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
 }


### PR DESCRIPTION
Other packages have a better sed to fix the local paths in TMPDIR problem. This change adds the same regex here.