### PR TITLE
[kirkstone] {humble} generate-parameter-library-example, generate-parameter-module-example: delete bbappends

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/generate-parameter-library/generate-parameter-library-example_0.5.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/generate-parameter-library/generate-parameter-library-example_0.5.0-1.bbappend
@@ -1,6 +1,0 @@
-# Copyright (c) 2022 Wind River Systems, Inc.
-
-ROS_BUILDTOOL_DEPENDS += " \
-    generate-parameter-library-py-native \
-    python3-pyyaml-native \
-"

--- a/meta-ros2-humble/recipes-bbappends/generate-parameter-library/generate-parameter-module-example_0.5.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/generate-parameter-library/generate-parameter-module-example_0.5.0-1.bbappend
@@ -1,5 +1,0 @@
-# Copyright (c) 2023 Wind River Systems, Inc.
-
-ROS_BUILDTOOL_DEPENDS += " \
-    generate-parameter-library-py-native \
-"


### PR DESCRIPTION
The recipes were deleted in:
https://github.com/ros/meta-ros/pull/1637
but bbappends weren't, causing parsing failure:
```
  ERROR: No recipes in default available for:
    meta-ros/meta-ros2-humble/recipes-bbappends/generate-parameter-library/generate-parameter-library-example_0.5.0-1.bbappend
    meta-ros/meta-ros2-humble/recipes-bbappends/generate-parameter-library/generate-parameter-module-example_0.5.0-1.bbappend
```