### PR TITLE
{common} python3-flake8-docstrings: Add python build backend

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python3-flake8-docstrings_1.7.0.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-flake8-docstrings_1.7.0.bb
@@ -7,6 +7,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a34bc20b983e1104e2d50423b224b087"
 PYPI_PACKAGE = "flake8_docstrings"
 SRC_URI[sha256sum] = "4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af"
 
-inherit pypi
+inherit pypi python_setuptools_build_meta
+
+RDEPENDS:${PN} = "python3-flake8 python3-pydocstyle"
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
Add python_setuptools_build_meta as python build backend class and also add missing python3-flake8 and python3-pydocstyle runtime dependencies. Otherwise, this recipe produces only empty packages (aside from the -lic package).

Fixes build errors like the one below:

Error:
 Problem: package packagegroup-xilinx-ros-dev-1.0-r0.1.cortexa72_cortexa53 from oe-repo requires ament-flake8, but none of the providers can be installed
  - conflicting requests
  - nothing provides python3-flake8-docstrings needed by ament-flake8-0.17.4+1-r0.1.cortexa72_cortexa53 from oe-repo