### PR TITLE
{kilted} apriltag: Fix build due to compiler warning

### DIFF
--- a/meta-ros2-kilted/recipes-bbappends/apriltag/apriltag_3.4.3-2.bbappend
+++ b/meta-ros2-kilted/recipes-bbappends/apriltag/apriltag_3.4.3-2.bbappend
@@ -5,3 +5,6 @@ inherit ros_insane_dev_so python3targetconfig
 DEPENDS += "python3-numpy-native"
 
 EXTRA_OECMAKE += "-DPY_DEST=${PYTHON_SITEPACKAGES_DIR}"
+
+# apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:646:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
+OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"


### PR DESCRIPTION
## Description

While trying to build the apriltag package for my Yocto OS (kilted/scarthgap) I get a compiler warning in a numpy header, breaking the build.

I fixed this with `OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"`.

My Yocto OS uses scarthgap/kilted, so I applied it there for testing, but can retarget different versions if the patch is wanted.

## How has this been tested?

Before, build fails with error:

```
| apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:847:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
|   847 |         (*(PyObject * (*)(PyTypeObject *, int, npy_intp const *, int, npy_intp const *, void *, int, int, PyObject *)) \
|       |           ^
| apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/ndarrayobject.h:118:9: note: in expansion of macro 'PyArray_New'
|   118 |         PyArray_New(&PyArray_Type, nd, dims, typenum, NULL, NULL, 0, 0, NULL)
|       |         ^~~~~~~~~~~
| apriltag/3.4.3-2/git/apriltag_pywrap.c:269:42: note: in expansion of macro 'PyArray_SimpleNew'
|   269 |         xy_lb_rb_rt_lt = (PyArrayObject*)PyArray_SimpleNew(2, ((npy_intp[]){4,2}), NPY_FLOAT64);
|       |                                          ^~~~~~~~~~~~~~~~~
| cc1: all warnings being treated as errors
```

After applying this patch (and also https://github.com/AprilRobotics/apriltag/pull/424), build succeeds.