### PR TITLE
{all} Fix apriltag/apriltag-ros

### DIFF
--- a/meta-ros1-noetic/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
+++ b/meta-ros1-noetic/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Backport [https://github.com/christianrauch/apriltag_ros/commit/5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40]
+
+Signed-off-by: Garrett Brown <garrett.brown@aclima.earth>
+
+From 5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sat, 6 Sep 2025 18:12:57 +0200
+Subject: [PATCH] update tf2 'convert' header
+
+---
+ src/conversion.cpp      | 2 +-
+ src/pose_estimation.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conversion.cpp b/src/conversion.cpp
+index b9b30a8..9b743ca 100644
+--- a/src/conversion.cpp
++++ b/src/conversion.cpp
+@@ -4,7 +4,7 @@
+ #include <geometry_msgs/msg/quaternion.hpp>
+ #include <geometry_msgs/msg/vector3.hpp>
+ #include <opencv2/core/mat.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ template<>
+ void tf2::convert(const Eigen::Quaterniond& eigen_quat, geometry_msgs::msg::Quaternion& msg_quat)
+diff --git a/src/pose_estimation.cpp b/src/pose_estimation.cpp
+index 35a9e11..3fb8446 100644
+--- a/src/pose_estimation.cpp
++++ b/src/pose_estimation.cpp
+@@ -3,7 +3,7 @@
+ #include <apriltag/apriltag_pose.h>
+ #include <apriltag/common/homography.h>
+ #include <opencv2/calib3d.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ 
+ geometry_msgs::msg::Transform
+-- 
+2.43.0
+

--- a/meta-ros1-noetic/recipes-bbappends/apriltag-ros/apriltag-ros_3.2.1-3.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/apriltag-ros/apriltag-ros_3.2.1-3.bbappend
@@ -3,6 +3,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://fix.apriltag.include.flag.patch \
+    file://0001-update-tf2-convert-header.patch \
 "
 
 # ERROR: apriltag-ros-3.1.1-1-r0 do_package_qa: QA Issue: /opt/ros/melodic/lib/apriltag_ros/analyze_image contained in package apriltag-ros requires /bin/bash, but no providers found in RDEPENDS:apriltag-ros? [file-rdeps]

--- a/meta-ros1-noetic/recipes-bbappends/apriltag/apriltag_3.2.0-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/apriltag/apriltag_3.2.0-1.bbappend
@@ -10,3 +10,6 @@ SRC_URI += " \
     file://fix.cflags.in.pkg-config.patch \
     file://0001-CMakeLists.txt-allow-to-set-PY_DEST.patch \
 "
+
+# apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:646:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
+OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"

--- a/meta-ros2-humble/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
+++ b/meta-ros2-humble/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Backport [https://github.com/christianrauch/apriltag_ros/commit/5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40]
+
+Signed-off-by: Garrett Brown <garrett.brown@aclima.earth>
+
+From 5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sat, 6 Sep 2025 18:12:57 +0200
+Subject: [PATCH] update tf2 'convert' header
+
+---
+ src/conversion.cpp      | 2 +-
+ src/pose_estimation.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conversion.cpp b/src/conversion.cpp
+index b9b30a8..9b743ca 100644
+--- a/src/conversion.cpp
++++ b/src/conversion.cpp
+@@ -4,7 +4,7 @@
+ #include <geometry_msgs/msg/quaternion.hpp>
+ #include <geometry_msgs/msg/vector3.hpp>
+ #include <opencv2/core/mat.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ template<>
+ void tf2::convert(const Eigen::Quaterniond& eigen_quat, geometry_msgs::msg::Quaternion& msg_quat)
+diff --git a/src/pose_estimation.cpp b/src/pose_estimation.cpp
+index 35a9e11..3fb8446 100644
+--- a/src/pose_estimation.cpp
++++ b/src/pose_estimation.cpp
+@@ -3,7 +3,7 @@
+ #include <apriltag/apriltag_pose.h>
+ #include <apriltag/common/homography.h>
+ #include <opencv2/calib3d.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ 
+ geometry_msgs::msg::Transform
+-- 
+2.43.0
+

--- a/meta-ros2-humble/recipes-bbappends/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
@@ -1,5 +1,10 @@
 # Copyright (c) 2023-2024 Wind River Systems, Inc.
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += " \
+    file://0001-update-tf2-convert-header.patch \
+"
+
 # apriltag-ros/3.1.2-1-r0/recipe-sysroot/usr/include/apriltag/common/matd.h:48:12: error: ISO C++ forbids flexible array member 'data' [-Werror=pedantic]
 CXXFLAGS += "-Wno-error=pedantic"
 

--- a/meta-ros2-humble/recipes-bbappends/apriltag/apriltag_3.4.5-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/apriltag/apriltag_3.4.5-1.bbappend
@@ -9,3 +9,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-CMakeLists.txt-allow-to-set-PY_DEST.patch \
 "
+
+# apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:646:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
+OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"

--- a/meta-ros2-jazzy/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Backport [https://github.com/christianrauch/apriltag_ros/commit/5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40]
+
+Signed-off-by: Garrett Brown <garrett.brown@aclima.earth>
+
+From 5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sat, 6 Sep 2025 18:12:57 +0200
+Subject: [PATCH] update tf2 'convert' header
+
+---
+ src/conversion.cpp      | 2 +-
+ src/pose_estimation.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conversion.cpp b/src/conversion.cpp
+index b9b30a8..9b743ca 100644
+--- a/src/conversion.cpp
++++ b/src/conversion.cpp
+@@ -4,7 +4,7 @@
+ #include <geometry_msgs/msg/quaternion.hpp>
+ #include <geometry_msgs/msg/vector3.hpp>
+ #include <opencv2/core/mat.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ template<>
+ void tf2::convert(const Eigen::Quaterniond& eigen_quat, geometry_msgs::msg::Quaternion& msg_quat)
+diff --git a/src/pose_estimation.cpp b/src/pose_estimation.cpp
+index 35a9e11..3fb8446 100644
+--- a/src/pose_estimation.cpp
++++ b/src/pose_estimation.cpp
+@@ -3,7 +3,7 @@
+ #include <apriltag/apriltag_pose.h>
+ #include <apriltag/common/homography.h>
+ #include <opencv2/calib3d.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ 
+ geometry_msgs::msg::Transform
+-- 
+2.43.0
+

--- a/meta-ros2-jazzy/recipes-bbappends/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Wind River Systems, Inc.
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += " \
+    file://0001-update-tf2-convert-header.patch \
+"
+
 # apriltag-ros/3.1.2-1-r0/recipe-sysroot/usr/include/apriltag/common/matd.h:48:12: error: ISO C++ forbids flexible array member 'data' [-Werror=pedantic]
 CXXFLAGS += "-Wno-error=pedantic"
 

--- a/meta-ros2-jazzy/recipes-bbappends/apriltag/apriltag_3.4.5-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/apriltag/apriltag_3.4.5-1.bbappend
@@ -9,3 +9,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-CMakeLists.txt-allow-to-set-PY_DEST.patch \
 "
+
+# apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:646:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
+OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"

--- a/meta-ros2-kilted/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
+++ b/meta-ros2-kilted/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Backport [https://github.com/christianrauch/apriltag_ros/commit/5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40]
+
+Signed-off-by: Garrett Brown <garrett.brown@aclima.earth>
+
+From 5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sat, 6 Sep 2025 18:12:57 +0200
+Subject: [PATCH] update tf2 'convert' header
+
+---
+ src/conversion.cpp      | 2 +-
+ src/pose_estimation.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conversion.cpp b/src/conversion.cpp
+index b9b30a8..9b743ca 100644
+--- a/src/conversion.cpp
++++ b/src/conversion.cpp
+@@ -4,7 +4,7 @@
+ #include <geometry_msgs/msg/quaternion.hpp>
+ #include <geometry_msgs/msg/vector3.hpp>
+ #include <opencv2/core/mat.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ template<>
+ void tf2::convert(const Eigen::Quaterniond& eigen_quat, geometry_msgs::msg::Quaternion& msg_quat)
+diff --git a/src/pose_estimation.cpp b/src/pose_estimation.cpp
+index 35a9e11..3fb8446 100644
+--- a/src/pose_estimation.cpp
++++ b/src/pose_estimation.cpp
+@@ -3,7 +3,7 @@
+ #include <apriltag/apriltag_pose.h>
+ #include <apriltag/common/homography.h>
+ #include <opencv2/calib3d.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ 
+ geometry_msgs::msg::Transform
+-- 
+2.43.0
+

--- a/meta-ros2-kilted/recipes-bbappends/apriltag-ros/apriltag-ros_3.2.2-2.bbappend
+++ b/meta-ros2-kilted/recipes-bbappends/apriltag-ros/apriltag-ros_3.2.2-2.bbappend
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Wind River Systems, Inc.
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += " \
+    file://0001-update-tf2-convert-header.patch \
+"
+
 # apriltag-ros/3.1.2-1-r0/recipe-sysroot/usr/include/apriltag/common/matd.h:48:12: error: ISO C++ forbids flexible array member 'data' [-Werror=pedantic]
 CXXFLAGS += "-Wno-error=pedantic"
 

--- a/meta-ros2-kilted/recipes-bbappends/apriltag/apriltag_3.4.3-2.bbappend
+++ b/meta-ros2-kilted/recipes-bbappends/apriltag/apriltag_3.4.3-2.bbappend
@@ -5,3 +5,6 @@ inherit ros_insane_dev_so python3targetconfig
 DEPENDS += "python3-numpy-native"
 
 EXTRA_OECMAKE += "-DPY_DEST=${PYTHON_SITEPACKAGES_DIR}"
+
+# apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:646:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
+OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"

--- a/meta-ros2-rolling/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
+++ b/meta-ros2-rolling/recipes-bbappends/apriltag-ros/apriltag-ros/0001-update-tf2-convert-header.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Backport [https://github.com/christianrauch/apriltag_ros/commit/5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40]
+
+Signed-off-by: Garrett Brown <garrett.brown@aclima.earth>
+
+From 5b73d4fd3eccdd0ccc6d17043f9f401ca04f6a40 Mon Sep 17 00:00:00 2001
+From: Christian Rauch <Rauch.Christian@gmx.de>
+Date: Sat, 6 Sep 2025 18:12:57 +0200
+Subject: [PATCH] update tf2 'convert' header
+
+---
+ src/conversion.cpp      | 2 +-
+ src/pose_estimation.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conversion.cpp b/src/conversion.cpp
+index b9b30a8..9b743ca 100644
+--- a/src/conversion.cpp
++++ b/src/conversion.cpp
+@@ -4,7 +4,7 @@
+ #include <geometry_msgs/msg/quaternion.hpp>
+ #include <geometry_msgs/msg/vector3.hpp>
+ #include <opencv2/core/mat.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ template<>
+ void tf2::convert(const Eigen::Quaterniond& eigen_quat, geometry_msgs::msg::Quaternion& msg_quat)
+diff --git a/src/pose_estimation.cpp b/src/pose_estimation.cpp
+index 35a9e11..3fb8446 100644
+--- a/src/pose_estimation.cpp
++++ b/src/pose_estimation.cpp
+@@ -3,7 +3,7 @@
+ #include <apriltag/apriltag_pose.h>
+ #include <apriltag/common/homography.h>
+ #include <opencv2/calib3d.hpp>
+-#include <tf2/convert.h>
++#include <tf2/convert.hpp>
+ 
+ 
+ geometry_msgs::msg::Transform
+-- 
+2.43.0
+

--- a/meta-ros2-rolling/recipes-bbappends/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
@@ -1,5 +1,10 @@
 # Copyright (c) 2023 Wind River Systems, Inc.
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += " \
+    file://0001-update-tf2-convert-header.patch \
+"
+
 # apriltag-ros/3.1.2-1-r0/recipe-sysroot/usr/include/apriltag/common/matd.h:48:12: error: ISO C++ forbids flexible array member 'data' [-Werror=pedantic]
 CXXFLAGS += "-Wno-error=pedantic"
 

--- a/meta-ros2-rolling/recipes-bbappends/apriltag/apriltag_3.4.5-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/apriltag/apriltag_3.4.5-1.bbappend
@@ -5,3 +5,6 @@ inherit ros_insane_dev_so python3targetconfig
 DEPENDS += "python3-numpy-native"
 
 EXTRA_OECMAKE += "-DPY_DEST=${PYTHON_SITEPACKAGES_DIR}"
+
+# apriltag/3.4.3-2/recipe-sysroot-native/usr/lib/python3.12/site-packages/numpy/core/include/numpy/__multiarray_api.h:646:11: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]
+OECMAKE_C_FLAGS:append = " -Wno-error=pedantic"


### PR DESCRIPTION
## Description

This PR replaces https://github.com/ros/meta-ros/pull/1660. It expands the scope by fixing apriltags and apriltags-ros for all ROS distros.

## How has this been tested?

Both patches tested on my Scarthgap/Kilted build.

Currently working on porting my whole OS to master/rolling (in preparation for wrynose LTS) but haven't gotten it to build yet.