### PR TITLE
{humble} ros-distro-recipe-blacklist.inc: Add BBMASK for libcamera bbappend

### DIFF
--- a/meta-ros2-humble/conf/ros-distro/include/humble/ros-distro-recipe-blacklist.inc
+++ b/meta-ros2-humble/conf/ros-distro/include/humble/ros-distro-recipe-blacklist.inc
@@ -201,3 +201,4 @@ SKIP_RECIPE[wiimote] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'cwiid', 
 SKIP_RECIPE[zenoh-bridge-dds] ?= "${@bb.utils.contains_any('ROS_WORLD_SKIP_GROUPS', ['clang', 'cargo'], 'clang: depends on clang which requires meta-clang layer; cargo: depends on cargo which requires meta-rust layer (or oe-core[honister] or newer)', '', d)}"
 
 BBMASK += "generated-recipes/libcamera/libcamera_.*.bb"
+BBMASK += "meta-ros2-humble/recipes-bbappends/libcamera/libcamera_0.1.0-3.bbappend"


### PR DESCRIPTION
The recipe was BBMASKed in:
https://github.com/ros/meta-ros/commit/207c726e0ea43f8468ad4528d2a7e78f062d946a now humble fails to parse with:
```
  ERROR: No recipes in default available for:
    meta-ros/meta-ros2-humble/recipes-bbappends/libcamera/libcamera_0.1.0-3.bbappend
```