### PR TITLE
[scarthgap]{ros2} xtl: Update SRCREV for 0.7.7

### DIFF
--- a/meta-ros2/recipes-support/xtl/xtl_0.7.7.bb
+++ b/meta-ros2/recipes-support/xtl/xtl_0.7.7.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c12cbcb0f50cce3b0c58db4e3db8c2da"
 SRC_URI = "git://github.com/xtensor-stack/xtl.git;protocol=https;branch=master"
 
 PV = "0.7.7+git${SRCPV}"
-SRCREV = "a7c1c5444dfc57f76620391af4c94785ff82c8d6"
+SRCREV = "d9c4d02cfe89ca62545c1c8f81a685d0349df83a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The git history was revised so the commit id for 0.7.7 has changed.

Cherry-pick: 2822f5d22d568e53d3e40630668e6e47dcd6e2f6 from master.