### PR TITLE
[scarthgap]{jazzy} ros2-control and ros2-canopen fixes

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/control-toolbox/control-toolbox_4.10.0-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/control-toolbox/control-toolbox_4.10.0-1.bbappend
@@ -1,0 +1,1 @@
+ROS_BUILDTOOL_DEPENDS += "generate-parameter-library-native"

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-base-driver/use-cmake-targets.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-base-driver/use-cmake-targets.patch
@@ -24,7 +24,7 @@ index 47c26e03..e942dc11 100644
 +  ${yaml_cpp_vendor_TARGETS}
 +  ${std_msgs_TARGETS}
 +  ${std_srvs_TARGETS}
-+  ${diagnostic_update_TARGETS}
++  ${diagnostic_updater_TARGETS}
  )
 
 
@@ -47,7 +47,7 @@ index 47c26e03..e942dc11 100644
 +  ${std_msgs_TARGETS}
 +  ${std_srvs_TARGETS}
 +  ${diagnostic_msgs_TARGETS}
-+  ${diagnostic_update_TARGETS}
++  ${diagnostic_updater_TARGETS}
  )
  message(STATUS "node_canopen_base_driver: ${lely_core_libraries_LIBRARIES}")
 
@@ -71,7 +71,7 @@ index 47c26e03..e942dc11 100644
 +  ${yaml_cpp_vendor_TARGETS}
 +  ${std_msgs_TARGETS}
 +  ${std_srvs_TARGETS}
-+  ${diagnostic_update_TARGETS}
++  ${diagnostic_updater_TARGETS}
  )
  # Causes the visibility macros to use dllexport rather than dllimport,
  # which is appropriate when building the dll but not consuming it.
@@ -92,7 +92,7 @@ index 47c26e03..e942dc11 100644
 +  ${yaml_cpp_vendor_TARGETS}
 +  ${std_msgs_TARGETS}
 +  ${std_srvs_TARGETS}
-+  ${diagnostic_update_TARGETS}
++  ${diagnostic_updater_TARGETS}
  )
 
  # Causes the visibility macros to use dllexport rather than dllimport,

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-fake-slaves/0001-Install-libmotion_generator-to-standard-lib-dir.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-fake-slaves/0001-Install-libmotion_generator-to-standard-lib-dir.patch
@@ -1,0 +1,28 @@
+From: Christian Kohn <chris.kohn@amd.com>
+Subject: [PATCH] Install libmotion_generator to standard lib dir
+
+The shared library was installed to lib/canopen_fake_slaves/ which is
+not in the runtime linker search path. Install it to lib/ instead so
+that cia402_slave_node can find it without requiring an RPATH.
+
+Upstream-Status: Pending
+
+AI-Generated: Claude Opus 4.6
+Signed-off-by: Christian Kohn <chris.kohn@amd.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1234567..abcdefg 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,7 +60,7 @@ target_link_libraries(
+ )
+ 
+ install(TARGETS motion_generator
+-DESTINATION lib/${PROJECT_NAME})
++DESTINATION lib)
+ 
+ install(TARGETS basic_slave_node
+   DESTINATION lib/${PROJECT_NAME})

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-fake-slaves_0.3.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-fake-slaves_0.3.2-1.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://0001-Install-libmotion_generator-to-standard-lib-dir.patch"

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-master-driver_0.3.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-master-driver_0.3.2-1.bbappend
@@ -1,0 +1,1 @@
+CXXFLAGS += "-Wno-error=format-security"

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests/0001-Add-missing-torque-actual-value-object-0x6077.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests/0001-Add-missing-torque-actual-value-object-0x6077.patch
@@ -1,0 +1,198 @@
+From: Christian Kohn <chris.kohn@amd.com>
+Subject: [PATCH] Add missing torque actual value object 0x6077 to cia402 EDS files
+
+The Cia402Driver unconditionally reads object 0x6077 via get_effort(),
+but 5 of the 6 cia402_slave.eds variants were missing this object.
+This caused a NULL pointer dereference in universal_get_value when
+the SDO read failed and the fallback dictionary lookup found no entry.
+
+Add [6077] (Torque Actual Value, INT16, ro) to the EDS files for
+cia402, cia402_diagnostics, cia402_lifecycle, cia402_namespaced_system,
+and cia402_system, matching the definition already present in
+robot_control/cia402_slave.eds.
+
+Upstream-Status: Pending
+
+AI-Generated: Claude Opus 4.6
+Signed-off-by: Christian Kohn <chris.kohn@amd.com>
+
+diff --git a/config/cia402/cia402_slave.eds b/config/cia402/cia402_slave.eds
+index 24be3815..66c3a70f 100644
+--- a/config/cia402/cia402_slave.eds
++++ b/config/cia402/cia402_slave.eds
+@@ -41,7 +41,7 @@ SupportedObjects=3
+ SupportedObjects=0
+ 
+ [OptionalObjects]
+-SupportedObjects=67
++SupportedObjects=68
+ 1=0x1005
+ 2=0x1008
+ 3=0x1009
+@@ -109,6 +109,7 @@ SupportedObjects=67
+ 65=0x60FF
+ 66=0x6502
+ 67=0x67FF
++68=0x6077
+ 
+ [1000]
+ ParameterName=Device Type
+@@ -1205,6 +1206,14 @@ DataType=0x0004
+ AccessType=ro
+ PDOMapping=1
+ 
++[6077]
++ParameterName=Torque Actual Value 1
++ObjectType=0x07
++DataType=0x0003
++AccessType=ro
++DefaultValue=0x0
++PDOMapping=1
++
+ [607A]
+ ParameterName=Target Position 1
+ ObjectType=0x07
+diff --git a/config/cia402_diagnostics/cia402_slave.eds b/config/cia402_diagnostics/cia402_slave.eds
+index 24be3815..66c3a70f 100644
+--- a/config/cia402_diagnostics/cia402_slave.eds
++++ b/config/cia402_diagnostics/cia402_slave.eds
+@@ -41,7 +41,7 @@ SupportedObjects=3
+ SupportedObjects=0
+ 
+ [OptionalObjects]
+-SupportedObjects=67
++SupportedObjects=68
+ 1=0x1005
+ 2=0x1008
+ 3=0x1009
+@@ -109,6 +109,7 @@ SupportedObjects=67
+ 65=0x60FF
+ 66=0x6502
+ 67=0x67FF
++68=0x6077
+ 
+ [1000]
+ ParameterName=Device Type
+@@ -1205,6 +1206,14 @@ DataType=0x0004
+ AccessType=ro
+ PDOMapping=1
+ 
++[6077]
++ParameterName=Torque Actual Value 1
++ObjectType=0x07
++DataType=0x0003
++AccessType=ro
++DefaultValue=0x0
++PDOMapping=1
++
+ [607A]
+ ParameterName=Target Position 1
+ ObjectType=0x07
+diff --git a/config/cia402_lifecycle/cia402_slave.eds b/config/cia402_lifecycle/cia402_slave.eds
+index d30fa434..322cc5cd 100644
+--- a/config/cia402_lifecycle/cia402_slave.eds
++++ b/config/cia402_lifecycle/cia402_slave.eds
+@@ -41,7 +41,7 @@ SupportedObjects=3
+ SupportedObjects=0
+ 
+ [OptionalObjects]
+-SupportedObjects=67
++SupportedObjects=68
+ 1=0x1005
+ 2=0x1008
+ 3=0x1009
+@@ -109,6 +109,7 @@ SupportedObjects=67
+ 65=0x60FF
+ 66=0x6502
+ 67=0x67FF
++68=0x6077
+ 
+ [1000]
+ ParameterName=Device Type
+@@ -1206,6 +1207,14 @@ DataType=0x0004
+ AccessType=ro
+ PDOMapping=1
+ 
++[6077]
++ParameterName=Torque Actual Value 1
++ObjectType=0x07
++DataType=0x0003
++AccessType=ro
++DefaultValue=0x0
++PDOMapping=1
++
+ [607A]
+ ParameterName=Target Position 1
+ ObjectType=0x07
+diff --git a/config/cia402_namespaced_system/cia402_slave.eds b/config/cia402_namespaced_system/cia402_slave.eds
+index 24be3815..66c3a70f 100644
+--- a/config/cia402_namespaced_system/cia402_slave.eds
++++ b/config/cia402_namespaced_system/cia402_slave.eds
+@@ -41,7 +41,7 @@ SupportedObjects=3
+ SupportedObjects=0
+ 
+ [OptionalObjects]
+-SupportedObjects=67
++SupportedObjects=68
+ 1=0x1005
+ 2=0x1008
+ 3=0x1009
+@@ -109,6 +109,7 @@ SupportedObjects=67
+ 65=0x60FF
+ 66=0x6502
+ 67=0x67FF
++68=0x6077
+ 
+ [1000]
+ ParameterName=Device Type
+@@ -1205,6 +1206,14 @@ DataType=0x0004
+ AccessType=ro
+ PDOMapping=1
+ 
++[6077]
++ParameterName=Torque Actual Value 1
++ObjectType=0x07
++DataType=0x0003
++AccessType=ro
++DefaultValue=0x0
++PDOMapping=1
++
+ [607A]
+ ParameterName=Target Position 1
+ ObjectType=0x07
+diff --git a/config/cia402_system/cia402_slave.eds b/config/cia402_system/cia402_slave.eds
+index 24be3815..66c3a70f 100644
+--- a/config/cia402_system/cia402_slave.eds
++++ b/config/cia402_system/cia402_slave.eds
+@@ -41,7 +41,7 @@ SupportedObjects=3
+ SupportedObjects=0
+ 
+ [OptionalObjects]
+-SupportedObjects=67
++SupportedObjects=68
+ 1=0x1005
+ 2=0x1008
+ 3=0x1009
+@@ -109,6 +109,7 @@ SupportedObjects=67
+ 65=0x60FF
+ 66=0x6502
+ 67=0x67FF
++68=0x6077
+ 
+ [1000]
+ ParameterName=Device Type
+@@ -1205,6 +1206,14 @@ DataType=0x0004
+ AccessType=ro
+ PDOMapping=1
+ 
++[6077]
++ParameterName=Torque Actual Value 1
++ObjectType=0x07
++DataType=0x0003
++AccessType=ro
++DefaultValue=0x0
++PDOMapping=1
++
+ [607A]
+ ParameterName=Target Position 1
+ ObjectType=0x07

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
@@ -1,0 +1,6 @@
+DEPENDS += "lely-core-libraries-native"
+
+# dcfgen and cogen are located in /opt/ros/<DISTRO>/bin
+do_compile:prepend:class-target() {
+    export PATH=${STAGING_DIR_NATIVE}${ros_bindir}:$PATH
+}

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
@@ -1,5 +1,8 @@
 DEPENDS += "lely-core-libraries-native"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/canopen-tests:"
+SRC_URI += "file://0001-Add-missing-torque-actual-value-object-0x6077.patch"
+
 # dcfgen and cogen are located in /opt/ros/<DISTRO>/bin
 do_compile:prepend:class-target() {
     export PATH=${STAGING_DIR_NATIVE}${ros_bindir}:$PATH

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
@@ -1,0 +1,6 @@
+DEPENDS += "lely-core-libraries-native"
+
+# dcfgen and cogen are located in /opt/ros/<DISTRO>/bin
+do_compile:prepend:class-target() {
+    export PATH="${STAGING_DIR_NATIVE}${ros_bindir}:$PATH"
+}

--- a/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/ros2-canopen/canopen-tests_0.3.2-1.bbappend
@@ -1,5 +1,8 @@
 DEPENDS += "lely-core-libraries-native"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/canopen-tests:"
+SRC_URI += "file://0001-Add-missing-torque-actual-value-object-0x6077.patch"
+
 # dcfgen and cogen are located in /opt/ros/<DISTRO>/bin
 do_compile:prepend:class-target() {
     export PATH="${STAGING_DIR_NATIVE}${ros_bindir}:$PATH"

--- a/meta-ros2-jazzy/recipes-devtools/tl-expected/tl-expected_1.3.1.bb
+++ b/meta-ros2-jazzy/recipes-devtools/tl-expected/tl-expected_1.3.1.bb
@@ -11,5 +11,9 @@ inherit cmake
 
 EXTRA_OECMAKE = "-DEXPECTED_BUILD_TESTS=FALSE"
 
+# Header-only library — create empty base package for runtime
+# dependency satisfaction
+ALLOW_EMPTY:${PN} = "1"
+
 BBCLASSEXTEND = "native"
 

--- a/meta-ros2-jazzy/recipes-devtools/tl-expected/tl-expected_1.3.1.bb
+++ b/meta-ros2-jazzy/recipes-devtools/tl-expected/tl-expected_1.3.1.bb
@@ -11,3 +11,5 @@ inherit cmake
 
 EXTRA_OECMAKE = "-DEXPECTED_BUILD_TESTS=FALSE"
 
+BBCLASSEXTEND = "native"
+

--- a/meta-ros2/recipes-devtools/tl-expected/tl-expected_1.3.1.bb
+++ b/meta-ros2/recipes-devtools/tl-expected/tl-expected_1.3.1.bb
@@ -12,4 +12,8 @@ inherit cmake
 
 EXTRA_OECMAKE = "-DEXPECTED_BUILD_TESTS=FALSE"
 
+# Header-only library — create empty base package for runtime
+# dependency satisfaction
+ALLOW_EMPTY:${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2/recipes-support/lely-core/lely-core/0001-Fix-dcf-tools.patch
+++ b/meta-ros2/recipes-support/lely-core/lely-core/0001-Fix-dcf-tools.patch
@@ -1,0 +1,82 @@
+Upstream-Status: Backport [https://github.com/ros-industrial/ros2_canopen/blob/master/lely_core_libraries/patches/0001-Fix-dcf-tools.patch]
+
+From 1fcc088cdf64bee181f1141077af01267cc224ad Mon Sep 17 00:00:00 2001
+From: Christoph Hellmann Santos <christoph.hellmann.santos@ipa.fraunhofer.de>
+Date: Tue, 27 Jun 2023 10:15:06 +0200
+Subject: [PATCH] Fix dcf-tools
+
+---
+ configure.ac                 | 10 +++-------
+ python/dcf-tools/Makefile.am | 23 +++++------------------
+ 2 files changed, 8 insertions(+), 25 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1dd9410d..c274636b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -569,19 +569,15 @@ AC_ARG_ENABLE([python],
+ 	AS_HELP_STRING([--disable-python], [disable Python tools and bindings]))
+
+ AM_CONDITIONAL([HAVE_PYTHON2], [false])
+-AC_ARG_ENABLE([python2],
+-	AS_HELP_STRING([--disable-python2], [disable Python 2 tools and bindings]))
+-AS_IF([test "$enable_python" == "no"], [enable_python2=no])
+-AS_IF([test "$enable_python2" != "no"], [
+-	AX_CHECK_PYTHON([2], [AM_CONDITIONAL([HAVE_PYTHON2], [true])])
+-])
+
+ AM_CONDITIONAL([HAVE_PYTHON3], [false])
+ AC_ARG_ENABLE([python3],
+ 	AS_HELP_STRING([--disable-python3], [disable Python 3 tools and bindings]))
+ AS_IF([test "$enable_python" == "no"], [enable_python3=no])
+ AS_IF([test "$enable_python3" != "no"], [
+-	AX_CHECK_PYTHON([3], [AM_CONDITIONAL([HAVE_PYTHON3], [true])])
++	AM_PATH_PYTHON([3.3],, [:])
++	AC_SUBST(PYTHON3, "$PYTHON")
++	AM_CONDITIONAL([HAVE_PYTHON3], [test "$PYTHON" != :])
+ ])
+
+ AM_CONDITIONAL([NO_CYTHON], [false])
+diff --git a/python/dcf-tools/Makefile.am b/python/dcf-tools/Makefile.am
+index 9852c84a..dd5cdfa0 100644
+--- a/python/dcf-tools/Makefile.am
++++ b/python/dcf-tools/Makefile.am
+@@ -23,30 +23,17 @@ EXTRA_DIST += setup.py
+ build_base = $(realpath $(builddir))/build
+ dist_dir = $(realpath $(builddir))/dist
+
+-all-local: python-sdist python-bdist_wheel
+-
+ clean-local:
+ 	rm -rf $(build_base) $(dist_dir) $(srcdir)/*.egg-info $(builddir)/*.egg-info
+
+ install-exec-local: python-install
+
+-.PHONY: python-bdist_wheel
+-python-bdist_wheel:
+-if HAVE_PYTHON3
+-	@$(PYTHON3_ENV) $(PYTHON3) $(srcdir)/setup.py \
+-		bdist_wheel --dist-dir $(dist_dir)
+-endif
+-
+ .PHONY: python-install
+ python-install:
+ if HAVE_PYTHON3
+-	@$(PYTHON3_ENV) $(PYTHON3) $(srcdir)/setup.py \
+-		install --prefix $(DESTDIR)$(prefix) --root /
+-endif
+-
+-.PHONY: python-sdist
+-python-sdist:
+-if HAVE_PYTHON3
+-	@cd $(srcdir); $(PYTHON3_ENV) $(PYTHON3) setup.py \
+-		sdist --dist-dir $(dist_dir)
++	@cd $(srcdir) && $(PYTHON3_ENV) $(PYTHON3) setup.py \
++		egg_info build install --record install.log \
++		--install-scripts $(DESTDIR)$(prefix)/bin/ \
++		--install-lib $(DESTDIR)$(prefix)/lib/python$(PYTHON_VERSION)/site-packages/ \
++		--single-version-externally-managed
+ endif
+--
+2.34.1
+

--- a/meta-ros2/recipes-support/lely-core/lely-core_2.3.5.bb
+++ b/meta-ros2/recipes-support/lely-core/lely-core_2.3.5.bb
@@ -5,7 +5,8 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRC_URI = "git://gitlab.com/lely_industries/lely-core.git;protocol=https;branch=v2.3 \
-    file://0001-fix-GCC-15-errors.patch"
+    file://0001-fix-GCC-15-errors.patch \
+    file://0001-Fix-dcf-tools.patch"
 
 SRCREV = "9e3267d26018f6f6babd50786f6ae2af89cc57ea"
 
@@ -15,7 +16,7 @@ inherit pkgconfig autotools setuptools3-base
 
 DEPENDS += "python3-setuptools-native python3-wheel-native"
 
-EXTRA_OECONF += " --disable-cython --disable-tests --disable-python2"
+EXTRA_OECONF += " --disable-cython --disable-tests"
 
 # include/lely/coapp/device.hpp:1003:3: error: 'virtual void lely::canopen::Device::OnWrite(uint16_t, uint8_t)' was hidden [-Werror=overloaded-virtual=]
 CXXFLAGS += "-Wno-error=overloaded-virtual"
@@ -161,40 +162,48 @@ FILES:liblely-util-dev = " \
 "
 
 FILES:python3-dcf-tools = " \
-    ${libdir}/python3*/dist-packages/dcf/*.py \
-    ${libdir}/python3*/dist-packages/dcfgen/data/ \
-    ${libdir}/python3*/dist-packages/dcfgen/*.py \
-    ${libdir}/python3*/dist-packages/dcf_tools-*.egg-info/ \
+    ${libdir}/python3*/site-packages/dcf/*.py \
+    ${libdir}/python3*/site-packages/dcfgen/data/ \
+    ${libdir}/python3*/site-packages/dcfgen/*.py \
+    ${libdir}/python3*/site-packages/dcf_tools-*.egg-info/ \
     ${bindir}/dcfchk \
     ${bindir}/dcfgen \
 "
 
 FILES:python3-lely-can-dev = " \
-    ${libdir}/python3*/dist-packages/lely_can/*.pxd \
+    ${libdir}/python3*/site-packages/lely_can/*.pxd \
 "
 
 FILES:python3-lely-can = " \
-    ${libdir}/python3*/dist-packages/lely_can/*.py \
-    ${libdir}/python3*/dist-packages/lely_can/*.so \
+    ${libdir}/python3*/site-packages/lely_can/*.py \
+    ${libdir}/python3*/site-packages/lely_can/*.so \
 "
 
 FILES:python3-lely-io-dev = " \
-    ${libdir}/python3*/dist-packages/lely_io/*.pxd \
+    ${libdir}/python3*/site-packages/lely_io/*.pxd \
 "
 
 FILES:python3-lely-io = " \
-    ${libdir}/python3*/dist-packages/lely_io/*.py \
-    ${libdir}/python3*/dist-packages/lely_io/*.so \
+    ${libdir}/python3*/site-packages/lely_io/*.py \
+    ${libdir}/python3*/site-packages/lely_io/*.so \
 "
 
 # QA Issue: lely-core: .../dcf2dev maximum shebang size exceeded, the maximum size is 128.
 #           lely-core: .../dcfchk maximum shebang size exceeded, the maximum size is 128.
 #           lely-core: .../dcfgen maximum shebang size exceeded, the maximum size is 128. [shebang-size]
 do_install:append() {
-    # Modify the Python scripts to use the runtime path to Python 
+    # Modify the Python scripts to use the runtime path to Python
     sed -i -e '1s|^#!.*|#!/usr/bin/env python3|' ${D}${bindir}/dcf2dev
     sed -i -e '1s|^#!.*|#!/usr/bin/env python3|' ${D}${bindir}/dcfchk
     sed -i -e '1s|^#!.*|#!/usr/bin/env python3|' ${D}${bindir}/dcfgen
+
+    # Recompile .pyc files with build paths stripped to avoid
+    # buildpaths QA warnings
+    for FILE in ${D}${PYTHON_SITEPACKAGES_DIR}/dcf/*.py \
+                ${D}${PYTHON_SITEPACKAGES_DIR}/dcf2dev/*.py \
+                ${D}${PYTHON_SITEPACKAGES_DIR}/dcfgen/*.py; do
+        nativepython3 -mcompileall -s ${D} $FILE
+    done
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This PR builds on top of https://github.com/ros/meta-ros/pull/1635 and also addresses https://github.com/ros/meta-ros/issues/1315 which is related.

Here is the set of packages that I'm including in my image for testing:

- canopen
- canopen-master-driver
- canopen-tests
- canopen-utils
- kernel-module-vcan
- python3-dcf-tools
- ros-base
- ros2-control

Here is my smoke test procedure:

```
sudo modprobe vcan
sudo ip link add dev vcan0 type vcan
sudo ip link set vcan0 txqueuelen 1000
sudo ip link set up vcan0
sudo ip link add dev vcan1 type vcan
sudo ip link set vcan1 txqueuelen 1000
sudo ip link set up vcan1
source /opt/ros/jazzy/setup.bash
ros2 launch canopen_tests cia402_setup.launch.py
```

@robwoolley I have backported the two patches you mentioned in the other pull request thread. I have added @graceagrace 's patches on top of that and reworked patches that overlapped/conflicted. Finally, I put another set of patches on top of that with additional fixes based on my testing.

Feel free to rework this as you see fit. I hope i gave proper credit to everyone and didn't goof up existing commits. Please speak up if i missed anything.