### PR TITLE
Vermaete/license

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/bond-core/bondcpp_%.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/bond-core/bondcpp_%.bbappend
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 LG Electronics, Inc.
 # Copyright (c) 2024 Wind River Systems, Inc.
 
-LICENSE = "BSD-3-Clause"
-
 ROS_BUILDTOOL_DEPENDS += "\
     rosidl-default-runtime-native \
 "

--- a/meta-ros2-rolling/recipes-bbappends/cpp-polyfills/tl-expected_1.2.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/cpp-polyfills/tl-expected_1.2.0-1.bbappend
@@ -1,2 +1,0 @@
-# Converting from Creative-Commons-Zero-v1.0-Universal to SPDX conform CC0-1.0
-LICENSE = "CC0-1.0"

--- a/meta-ros2-rolling/recipes-bbappends/event-camera-msgs/event-camera-msgs_2.0.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/event-camera-msgs/event-camera-msgs_2.0.1-1.bbappend
@@ -1,7 +1,5 @@
 # Copyright (c) 2024 Wind River Systems, Inc.
 
-LICENSE = "Apache-2.0"
-
 ROS_BUILDTOOL_DEPENDS += "\
     rosidl-default-runtime-native \
 "

--- a/meta-ros2-rolling/recipes-bbappends/perception-pcl/pcl-conversions_2.8.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/perception-pcl/pcl-conversions_2.8.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LICENSE = "BSD-3-Clause"

--- a/meta-ros2-rolling/recipes-bbappends/perception-pcl/pcl-ros_2.8.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/perception-pcl/pcl-ros_2.8.0-1.bbappend
@@ -1,5 +1,3 @@
-LICENSE = "BSD-3-Clause"
-
 # QA Issue: File /opt/ros/rolling/share/pcl_ros/cmake/export_pcl_rosExport.cmake in package pcl-ros-dev contains reference to TMPDIR [buildpaths]
 do_install:append() {
     sed -i -e "s#${RECIPE_SYSROOT}##g" ${D}${ros_datadir}/pcl_ros/cmake/export_pcl_rosExport.cmake

--- a/meta-ros2-rolling/recipes-bbappends/perception-pcl/perception-pcl_2.8.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/perception-pcl/perception-pcl_2.8.0-1.bbappend
@@ -1,2 +1,0 @@
-LICENSE = "BSD-3-Clause"
-

--- a/meta-ros2-rolling/recipes-bbappends/pinocchio/pinocchio_%.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/pinocchio/pinocchio_%.bbappend
@@ -1,7 +1,5 @@
 # Copyright (c) 2023 Wind River Systems, Inc.
 
-LICENSE = "BSD-2-Clause"
-
 ROS_BUILDTOOL_DEPENDS:remove = "clang-native-native"
 
 ROS_BUILDTOOL_DEPENDS += "\


### PR DESCRIPTION
A few license variable that are not longer needed in the bbappend files.
The string in the generated recipes was the same as in the bbappend files.