### PR TITLE
{rolling} ros-distro: clang-format and clang-tidy are not resolved

### DIFF
--- a/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro.inc
+++ b/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro.inc
@@ -327,10 +327,6 @@ ROS_UNRESOLVED_DEP-sdformat12 = "sdformat"
 ROS_UNRESOLVED_DEP-libopenscenegraph = "openscenegraph"
 ROS_UNRESOLVED_DEP-wireless-tools = "wireless-tools"
 ROS_UNRESOLVED_DEP-warehouse-ros-mongo = "warehouse-ros-mongo"
-ROS_UNRESOLVED_DEP-clang-format = "clang"
-ROS_UNRESOLVED_DEP-clang-format-native = "clang-native"
-ROS_UNRESOLVED_DEP-clang-tidy = "clang"
-ROS_UNRESOLVED_DEP-clang-tidy-native = "clang-native"
 
 ROS_UNRESOLVED_DEP-ignition-fuel-tools7 = "ignition-fuel-tools7"
 


### PR DESCRIPTION
@see: https://github.com/ros/rosdistro/commit/bb1a8d0396133ea969829f926558da27cf3d2093