### PR TITLE
libflann: Make OpenMP and tests configurable

### DIFF
--- a/meta-ros-common/recipes-extended/libflann/libflann_1.9.2.bb
+++ b/meta-ros-common/recipes-extended/libflann/libflann_1.9.2.bb
@@ -11,15 +11,31 @@ SRC_URI = "git://github.com/mariusmuja/flann;${ROS_BRANCH};protocol=https"
 
 inherit cmake pkgconfig
 
-DEPENDS = "hdf5 lz4 openmp"
+DEPENDS = " \
+    hdf5 \
+    lz4 \
+"
+
+PACKAGECONFIG ??= " \
+    openmp \
+    tests \
+"
+
+# Default OpenMP provider
+PACKAGECONFIG[openmp] = "-DUSE_OPENMP=ON,-DUSE_OPENMP=OFF,openmp,"
+
+# Alternative OpenMP provider for distros that use GCC libgomp instead of the
+# openmp recipe
+PACKAGECONFIG[gomp] = "-DUSE_OPENMP=ON,-DUSE_OPENMP=OFF,gcc-runtime,libgomp"
+
+# Build the upstream test binaries
+PACKAGECONFIG[tests] = "-DBUILD_TESTS=ON,-DBUILD_TESTS=OFF,,"
 
 # Prevent it finding python
 EXTRA_OECMAKE = "\
     -DBUILD_MATLAB_BINDINGS=OFF \
     -DBUILD_PYTHON_BINDINGS=OFF \
     -DUSE_MPI=ON \
-    -DUSE_OPENMP=ON \
-    -DBUILD_TESTS=ON \
     -DBUILD_CUDA_LIB=OFF \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 "


### PR DESCRIPTION
## Description

This PR introduces `PACKAGECONFIG` options to allow openmp to be disabled or to use libgomp, in addition to being able to disable building tests.

As a result, a downstream meta-layer can use a bbappend to control the build behavior of libflann, e.g.:

```bitbake
# Avoid the clang-backed openmp recipe; use GCC libgomp instead
PACKAGECONFIG:remove = "openmp"
PACKAGECONFIG:append = " gomp"

# Disable building tests
PACKAGECONFIG:remove = "tests"
```

## Motivation and context

In my distro conf, I do:

```
SKIP_RECIPE[clang] = "Clang is not allowed."
```

Because flann uses the clang-provided openmp package, I get:

```
ERROR: Nothing PROVIDES 'clang' (but meta-clang/recipes-devtools/clang/openmp_git.bb DEPENDS on or otherwise requires it)
clang was skipped: Recipe will be skipped because: Clang is not allowed.
Missing or unbuildable dependency chain was: ['oasis-perception-cpp', 'pcl', 'libflann', 'openmp', 'clang']
```

## How has this been tested?

With clang blocked, and this PR applied, and my bitbake bbappend pasted above, the build succeeds.