### PR TITLE
[scarthgap] off-highway-can: Remove obsolete LICENSE override bbappends

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_0.12.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_0.12.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2024 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 & MIT"

--- a/meta-ros2-jazzy/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 && MIT"

--- a/meta-ros2-rolling/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 && MIT"


### PR DESCRIPTION
Remove obsolete off-highway-can LICENSE override bbappends for jazzy, rolling, and humble. The bbappends were originally added to fix an invalid SPDX operator (&& instead of &) in the generated recipes, but the generated recipes have since been fixed upstream. The jazzy and rolling bbappends were renamed from 1.0.0-1 to 1.3.0-1 as part of bulk version renames, which preserved the invalid && syntax and caused a parse error:

`error in 'Apache-2.0 && MIT': invalid syntax`

Notes:
  - The humble bbappend had the correct & syntax but is equally redundant since the generated recipe is also correct
  - Verified all three generated recipes have LICENSE = "Apache-2.0 & MIT" (correct)