### PR TITLE
[master]{ros2|common} jasper: remove not longer used recipe

### DIFF
--- a/meta-ros-common/recipes-graphics/jasper/jasper_%.bbappend
+++ b/meta-ros-common/recipes-graphics/jasper/jasper_%.bbappend
@@ -1,1 +1,0 @@
-BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2/recipes-graphics/jasper/jasper_%.bbappend
+++ b/meta-ros2/recipes-graphics/jasper/jasper_%.bbappend
@@ -1,5 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LDFLAGS += "-lm"
-
-BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The recipe jasper is not used in meta-ros nor in ros itself.

see: https://github.com/ros/rosdistro/issues/51549