### PR TITLE
[wrynose] Remove invalid LICENSE for off-highway-can bbappends

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_0.12.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_0.12.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2024 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 & MIT"

--- a/meta-ros2-jazzy/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 && MIT"

--- a/meta-ros2-lyrical/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-3.bbappend
+++ b/meta-ros2-lyrical/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-3.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 && MIT"

--- a/meta-ros2-rolling/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_1.3.0-1.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2025 Wind River Systems, Inc.
-
-LICENSE = "Apache-2.0 && MIT"


### PR DESCRIPTION
Remove invalid LICENSE for off-highway-can bbappends in rolling, jazzy and humble.

The bbappend set LICENSE = "Apache-2.0 && MIT" using '&&' which is invalid BitBake syntax and causes a parse error:
      error in 'Apache-2.0 && MIT': invalid syntax
    
The correct operator is '&'.  Remove the bbappend entirely so the base generated recipe's LICENSE value is used without the invalid override.
