### PR TITLE
[master]{ros2} python3-construct: version bump 2.10.68 -> 2.10.70

### DIFF
--- a/meta-ros2/recipes-devtools/python/python3-construct_2.10.70.bb
+++ b/meta-ros2/recipes-devtools/python/python3-construct_2.10.70.bb
@@ -1,20 +1,18 @@
 SUMMARY = "Declarative data structures for python"
-HOMEPAGE = "https://construct.readthedocs.io/"
 DESCRIPTION = "Declarative data structures for python that allow symmetric parsing and building"
+HOMEPAGE = "https://construct.readthedocs.io/"
 SECTION = "devel/python"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=202b39559c1c79fe4715ce81e9e0ac02"
 
 SRC_URI = "git://github.com/construct/construct.git;protocol=https;branch=master"
 
-SRCREV = "a6603d7821480fb5a4e6665c6fd8028ce574c4bd"
+SRCREV = "c25a47172d4bde392b7ad188175b07b319d3dea4"
 
-# inherit pypi
 inherit setuptools3
 
 #RDEPENDS:${PN} = "\
 #  ${PYTHON_PN}-unittest \
 #  "
-
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
and some oelint-adv warnings