### PR TITLE
[master]{meta-ros2} python3-rosdoc2: adding ptest

### DIFF
--- a/meta-ros2/recipes-devtools/python/python3-rosdoc2/0001-ptest-fix-the-path-to-the-installed-package.patch
+++ b/meta-ros2/recipes-devtools/python/python3-rosdoc2/0001-ptest-fix-the-path-to-the-installed-package.patch
@@ -1,0 +1,36 @@
+From de8b15a327f8c3ddceeb08e7af46159fbd85cb67 Mon Sep 17 00:00:00 2001
+From: Jan Vermaete <jan.vermaete@gmail.com>
+Date: Mon, 6 Jul 2026 11:33:09 +0200
+Subject: [PATCH 1/1] ptest: fix the path to the installed package
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Jan Vermaete <jan.vermaete@gmail.com>
+---
+ test/test_flake8.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/test/test_flake8.py b/test/test_flake8.py
+index 38bfc5e..3138c9a 100644
+--- a/test/test_flake8.py
++++ b/test/test_flake8.py
+@@ -15,6 +15,7 @@
+ import logging
+ import os
+ import sys
++import sysconfig
+ 
+ import pytest
+ 
+@@ -37,7 +38,7 @@ def test_flake8():
+     )
+ 
+     report = style_guide.check_files([
+-        os.path.join(os.path.dirname(__file__), '..', 'rosdoc2'),
++        os.path.join(sysconfig.get_paths()["purelib"], 'rosdoc2'),
+     ])
+     report_tests = style_guide_tests.check_files([
+         os.path.join(os.path.dirname(__file__), '..', 'test'),
+-- 
+2.47.3
+

--- a/meta-ros2/recipes-devtools/python/python3-rosdoc2_0.2.1.bb
+++ b/meta-ros2/recipes-devtools/python/python3-rosdoc2_0.2.1.bb
@@ -7,13 +7,19 @@ DESCRIPTION = "\
 "
 HOMEPAGE = "https://github.com/ros-infrastructure/rosdoc2"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=10;endline=10;md5=d36ab912b8b544b7412f2d84c52072f1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRC_URI[sha256sum] = "fbb2ba4d0d867590955963363bf24b969c6ed18c24d730845b38884736b8ccf7"
+SRC_URI = "\
+    git://github.com/ros-infrastructure/rosdoc2.git;branch=main;protocol=https \
+    file://0001-ptest-fix-the-path-to-the-installed-package.patch \
+"
 
-inherit pypi python_setuptools_build_meta
+SRCREV = "978d4a81812504bf93964ecc41ea3022cfa49387"
+
+inherit python_setuptools_build_meta ptest-python-pytest
 
 RDEPENDS:${PN} = "\
+    doxygen \
     osrf-pycommon \
     python3-breathe \
     python3-catkin-pkg \
@@ -28,5 +34,18 @@ RDEPENDS:${PN} = "\
     "
 
 PYPI_PACKAGE = "rosdoc2"
+
+RDEPENDS:${PN}-ptest += "\
+    python3-flake8 \
+    python3-pycodestyle \
+"
+
+PTEST_PYTEST_DIR = "test"
+
+do_install_ptest:append() {
+    install -d ${D}${PTEST_PATH}
+    install -m 0644 ${S}/setup.cfg ${D}${PTEST_PATH}/
+    cp -r ${S}/test/packages ${D}${PTEST_PATH}/
+}
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
* Changed fetching from pypi to git because the tests are missing in the pypi archive.

* Added the missign doxgen as RDEPENDS

* ptest

    ```
    PASS: test/test_builder.py:test_minimum_package
    PASS: test/test_builder.py:test_full_package
    PASS: test/test_builder.py:test_only_python
    PASS: test/test_builder.py:test_src_python
    PASS: test/test_builder.py:test_false_python
    PASS: test/test_builder.py:test_invalid_python_source
    PASS: test/test_builder.py:test_too_many_python_packages
    PASS: test/test_builder.py:test_only_messages
    PASS: test/test_builder.py:test_basic_cpp
    PASS: test/test_flake8.py:test_flake8
    ============================================================================
    Testsuite summary
    # TOTAL: 10
    # PASS: 10
    # SKIP: 0
    # XFAIL: 0
    # FAIL: 0
    # XPASS: 0
    # ERROR: 0
    ```