### PR TITLE
[wrynose]{lyrical} gz-cmake: Add recipe for 5.1.1

### DIFF
--- a/meta-ros-common/recipes-devtools/gazebo/gz-cmake_5.1.1.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-cmake_5.1.1.bb
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+SUMMARY = "A set of CMake modules that are used by the C++-based Gazebo projects"
+HOMEPAGE = "https://gazebosim.org/libs/cmake/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a461be67a1edf991251f85f3aadd1d0"
+
+SRC_URI = "git://github.com/gazebosim/gz-cmake.git;protocol=https;branch=gz-cmake5 \
+           file://Fix-pkgconfig-install-dir.patch"
+
+SRCREV = "b71b3794087cbee28decb7f9223d3c9441685b76"
+
+inherit cmake
+
+FILES:${PN} += "${datadir}/gz/gz-cmake/*"
+
+FILES:${PN}-dev += "\
+    pkgconfig/gz-cmake5.pc \
+    ${includedir} \
+    ${datadir}/cmake/gz-cmake/cmake/ \
+    ${datadir}/gz/gz-cmake/ \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2-lyrical/conf/ros-distro/include/lyrical/ros-distro-preferred-versions.inc
+++ b/meta-ros2-lyrical/conf/ros-distro/include/lyrical/ros-distro-preferred-versions.inc
@@ -24,7 +24,7 @@ PREFERRED_VERSION_dartsim = "6.16.6"
 
 PREFERRED_VERSION_ogre-next = "3.0.0"
 
-PREFERRED_VERSION_gz-cmake = "5.1.0"
+PREFERRED_VERSION_gz-cmake = "5.1.1"
 PREFERRED_VERSION_gz-common = "7.1.1"
 PREFERRED_VERSION_gz-fuel_tools = "11.0.0"
 PREFERRED_VERSION_gz-gui = "10.0.0"


### PR DESCRIPTION
The lyrical layer's gz-cmake-vendor 0.4.5-1 tracks upstream gz-cmake 5.1.1,
but the layers currently ship gz-cmake 5.1.0.

This adds a gz-cmake 5.1.1 recipe (SRCREV matches the upstream
gz-cmake5_5.1.1 tag) alongside the existing 5.1.0 recipe, and updates
PREFERRED_VERSION_gz-cmake for lyrical.

Rolling is intentionally left at 5.1.0, as its gz-cmake-vendor (0.4.4-1)
still tracks that version.