### PR TITLE
[wrynose] osrf-pycommon: Fix unsatisfiable python3-osrf-pycommon runtime dependency

### DIFF
--- a/meta-ros2-lyrical/recipes-bbappends/osrf-pycommon/osrf-pycommon_2.1.7-3.bbappend
+++ b/meta-ros2-lyrical/recipes-bbappends/osrf-pycommon/osrf-pycommon_2.1.7-3.bbappend
@@ -1,6 +1,10 @@
-PACKAGES += "${PYTHON_PN}-${PN}"
+# launch-ros RDEPENDS on "python3-osrf-pycommon" (via the
+# ROS_UNRESOLVED_DEP mapping), but in this layer the python modules are
+# packaged into ${PN} (ros_opt_prefix claims site-packages for the base
+# package), leaving a declared python3-${PN} subpackage empty and
+# ungenerated. Provide the alias from the package that has the content.
+RPROVIDES:${PN} += "python3-osrf-pycommon"
 
 FILES:${PN} += "${datadir}/ament_index/resource_index/packages/osrf_pycommon"
-FILES:${PYTHON_PN}-${PN} = "${PYTHON_SITEPACKAGES_DIR}/*"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Building a lyrical image that includes launch-ros fails in do_rootfs:

```
Error:
 Problem: nothing provides python3-osrf-pycommon needed by launch-ros-0.29.8+1-r0
```

launch-ros has a runtime dependency on python3-osrf-pycommon (via the
ROS_UNRESOLVED_DEP mapping). The existing osrf-pycommon bbappend declares a
${PYTHON_PN}-${PN} subpackage for this, but the python modules are packaged
into the base package (ros_opt_prefix assigns the site-packages files to
${PN}, which is processed first in PACKAGES order), so the subpackage stays
empty and is never generated — the dependency is unsatisfiable.

This change provides the python3-osrf-pycommon name from the base package,
which actually contains the modules, and drops the ineffective subpackage
declaration. rpm -qp --provides on the resulting package lists
python3-osrf-pycommon, and image builds with launch-ros succeed.

Verified on wrynose with ROS_DISTRO=lyrical: do_rootfs of an image pulling
in launch-ros completes with this change and no other osrf-pycommon
overrides in the build.

Notes:

- An alternative would be to make the subpackage real by reordering the
  package assignment (PACKAGES =+ instead of +=) so the python package
  claims the site-packages files first. RPROVIDES was chosen as the minimal
  change that is verified; happy to rework if you prefer the subpackage
  approach.
- The rolling layer carries an identical bbappend
  (osrf-pycommon_2.1.7-1.bbappend) with the same latent problem. It is left
  untouched here since we can only verify lyrical, but the same fix should
  apply.