### PR TITLE
[wrynose]{lyrical} foonathan-memory-vendor: Fix system foonathan-memory detection

### DIFF
--- a/meta-ros2-lyrical/recipes-bbappends/foonathan-memory-vendor/foonathan-memory-vendor/0001-Use-in-process-find_package-for-system-foonathan_me.patch
+++ b/meta-ros2-lyrical/recipes-bbappends/foonathan-memory-vendor/foonathan-memory-vendor/0001-Use-in-process-find_package-for-system-foonathan_me.patch
@@ -1,0 +1,45 @@
+From: Max Weber-Hohengrund <max.weber-hohengrund@roboa.ch>
+Date: Thu, 9 Jul 2026 00:00:00 +0200
+Subject: [PATCH] Use in-process find_package for system foonathan_memory
+
+The existence check spawns a child cmake via `cmake --find-package`,
+which does not inherit the cross toolchain file, CMAKE_SYSROOT or
+CMAKE_FIND_ROOT_PATH, so a foonathan_memory staged in the Yocto/OE
+recipe sysroot is never found and the vendor falls back to cloning at
+build time -- which fails under bitbake's network-isolated do_compile.
+Use a normal in-process find_package(), which respects the toolchain
+context.
+
+Upstream-Status: Pending
+Signed-off-by: Max Weber-Hohengrund <max.weber-hohengrund@roboa.ch>
+---
+ CMakeLists.txt | 15 +++++----------
+ 1 file changed, 5 insertions(+), 10 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 769f1d1..ff507d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,17 +4,12 @@ project(foonathan_memory_vendor VERSION "1.4.1")
+ option(FOONATHAN_MEMORY_FORCE_VENDORED_BUILD
+         "Force foonathan memory vendor package build even if it is already installed in the system" OFF)
+ 
++set(_EXIT_CODE 1)
+ if(NOT FOONATHAN_MEMORY_FORCE_VENDORED_BUILD)
+-  execute_process(COMMAND
+-      ${CMAKE_COMMAND}
+-      --find-package
+-      -DNAME=foonathan_memory
+-      -DCOMPILER_ID=$<IF:$<BOOL:${WIN32}>,MSVC,GNU>
+-      -DLANGUAGE=CXX
+-      -DMODE=EXIST
+-      -DCMAKE_FIND_DEBUG_MODE=ON
+-    ERROR_QUIET
+-    RESULT_VARIABLE _EXIT_CODE)
++  find_package(foonathan_memory QUIET)
++  if(foonathan_memory_FOUND)
++    set(_EXIT_CODE 0)
++  endif()
+ endif()
+ 
+ if(NOT _EXIT_CODE EQUAL 0)

--- a/meta-ros2-lyrical/recipes-bbappends/foonathan-memory-vendor/foonathan-memory-vendor_1.4.1-1.bbappend
+++ b/meta-ros2-lyrical/recipes-bbappends/foonathan-memory-vendor/foonathan-memory-vendor_1.4.1-1.bbappend
@@ -1,5 +1,13 @@
 # Copyright (c) 2019 LG Electronics, Inc.
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+# Since 1.4.1 the vendor checks for a system foonathan_memory by spawning a
+# child cmake via `cmake --find-package`, which does not inherit the cross
+# toolchain/sysroot. The staged library is never found and the vendor falls
+# back to cloning at build time, which the network-isolated do_compile blocks.
+SRC_URI += "file://0001-Use-in-process-find_package-for-system-foonathan_me.patch"
+
 ROS_BUILD_DEPENDS += "\
     foonathan-memory \
 "


### PR DESCRIPTION
Building foonathan-memory-vendor 1.4.1-1 on lyrical fails: do_configure
reports "foonathan_memory not found." although foonathan-memory is staged
in the sysroot (via this layer's existing bbappend), and the vendor then
falls back to cloning github.com/foonathan/memory at build time, which the
network-isolated do_compile blocks ("Could not resolve host").

Since 1.4.1 the vendor checks for the system library by spawning a child
cmake via `cmake --find-package` (deprecated CMake functionality), which
does not inherit the cross toolchain file, CMAKE_SYSROOT or
CMAKE_FIND_ROOT_PATH. Kilted's vendor 1.3.1 checked in-process and was
unaffected. The patch switches the check to a normal in-process
find_package(), which respects the toolchain context.

This blocks the default Fast DDS path on wrynose/lyrical. Verified in
production image builds on wrynose/lyrical. We intend to submit the fix to
eProsima/foonathan_memory_vendor as well and will update the
Upstream-Status accordingly.