### PR TITLE
Vermaete/space ros

### DIFF
--- a/meta-spaceros-jazzy/generated-recipes-moveit2/realtime-tools/realtime-tools_3.11.0.bb
+++ b/meta-spaceros-jazzy/generated-recipes-moveit2/realtime-tools/realtime-tools_3.11.0.bb
@@ -12,7 +12,7 @@ DESCRIPTION = "\
 AUTHOR = "Bence Magyar <bence.magyar.robotics@gmail.com>"
 ROS_AUTHOR = "Stuart Glaser <sglaser@willowgarage.com>"
 HOMEPAGE = "https://control.ros.org"
-LICENSE = "3-Clause BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=86277dc780fe4e3edb08cd487093d9de"
 
 ROS_CN = "realtime_tools"

--- a/meta-spaceros-jazzy/generated-recipes-moveit2/ros-industrial-cmake-boilerplate/ros-industrial-cmake-boilerplate_0.5.4.bb
+++ b/meta-spaceros-jazzy/generated-recipes-moveit2/ros-industrial-cmake-boilerplate/ros-industrial-cmake-boilerplate_0.5.4.bb
@@ -9,7 +9,7 @@ DESCRIPTION = "Contains boilerplate cmake script, macros and utils"
 AUTHOR = "Levi Armstrong <levi.armstrong@gmail.com>"
 ROS_AUTHOR = "Levi Armstrong"
 HOMEPAGE = "https://wiki.ros.org"
-LICENSE = "Apache-2.0 & BSD 3-Clause"
+LICENSE = "Apache-2.0 & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=3dce4ba60d7e51ec64f3c3dc18672dd3"
 
 ROS_CN = "ros_industrial_cmake_boilerplate"


### PR DESCRIPTION
Two typo's in the value of the generated LICENSE variable of the bitbake recipe.
For both a change was send to the upstream projects.
I assume no need for a bbappend.  Both could be applied before a new sync.