### PR TITLE
[master]{humble} sick-scan-xd: remove bbappend file

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/sick-scan/sick-scan-xd_3.9.0-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/sick-scan/sick-scan-xd_3.9.0-1.bbappend
@@ -1,4 +1,0 @@
-# Copyright (C) 2024 Advanced Micro Devices, Inc.  All rights reserved.
-
-_LICENSE := "${LICENSE}"
-LICENSE = "${@'${_LICENSE}'.replace('Apache-License,-Version-2.0,-see-"http-www.apache.org-licenses-LICENSE-2.0"', 'Apache-2.0')}"


### PR DESCRIPTION
The LICENSE string in the bb file is now correct and no longer needs fixing.