### PR TITLE
[master]{ros2} zenoh|zenoh-c: set PACKAGECONFIG to shared-memory…

### DIFF
--- a/meta-ros2/conf/layer.conf
+++ b/meta-ros2/conf/layer.conf
@@ -23,9 +23,10 @@ LAYERDEPENDS_ros2-layer = " \
 BBFILES_DYNAMIC += " \
     qt6-layer:${LAYERDIR}/dynamic-layers/meta-qt6/recipes-*/*/*.bb \
     qt6-layer:${LAYERDIR}/dynamic-layers/meta-qt6/recipes-*/*/*.bbappend \
+    zenoh-layer:${LAYERDIR}/dynamic-layers/meta-zenoh/recipes-*/*/*.bbappend \
 "
 
 LAYERSERIES_COMPAT_ros2-layer = "wrynose"
-LAYERRECOMMENDS_ros2-layer = "qt6-layer"
+LAYERRECOMMENDS_ros2-layer = "qt6-layer zenoh-layer"
 
 ROS_OE_DISTRO_NAME ?= "Robot Operating System 2 (ROS 2)"

--- a/meta-ros2/dynamic-layers/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c_%.bbappend
+++ b/meta-ros2/dynamic-layers/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "shared-memory unstable-api"

--- a/meta-ros2/dynamic-layers/meta-zenoh/recipes-connectivity/zenoh/zenoh_%.bbappend
+++ b/meta-ros2/dynamic-layers/meta-zenoh/recipes-connectivity/zenoh/zenoh_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "shared-memory unstable-api "


### PR DESCRIPTION
… and unstable-api

These configuration are needed for meta-ros2.  But are not default enabled in meta-zenoh.
