### PR TITLE
[all]kas: zenoh config moved to meta-ros2

### DIFF
--- a/kas/layer/zenoh.yml
+++ b/kas/layer/zenoh.yml
@@ -10,8 +10,6 @@ repos:
 
 local_conf_header:
   zenoh: |
-    ZENOH_SHARED_MEMORY = "true"
-    ZENOH_UNSTABLE_API = "true"
     INSANE_SKIP:pn-zenoh-c += "buildpaths"
     # Needed for scarthgap
     DEBUG_PREFIX_MAP:remove:pn-zenoh-c = "-fcanon-prefix-map"


### PR DESCRIPTION
The configuration of the shared_memory and the unstable_api is added to meta-ros2

There is no need anymore to enable this in Kas.

@see: https://github.com/ros/meta-ros/pull/1788