### PR TITLE
[master]{common} python3-junitparser: new recipe at 5.0.1

### DIFF
--- a/meta-ros-common/recipes-devtools/python3-junitparser/python3-junitparser/0001-ptest-remove-the-src.-package.patch
+++ b/meta-ros-common/recipes-devtools/python3-junitparser/python3-junitparser/0001-ptest-remove-the-src.-package.patch
@@ -1,0 +1,108 @@
+From 20bb30a2eaf3b9823c59bd0fb1576200a3a581d4 Mon Sep 17 00:00:00 2001
+From: Jan Vermaete <jan.vermaete@oip.be>
+Date: Sun, 2 Aug 2026 14:43:40 +0200
+Subject: [PATCH 1/2] ptest: remove the 'src.' package
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Jan Vermaete <jan.vermaete@oip.be>
+---
+ tests/test_cli.py      | 4 ++--
+ tests/test_fromfile.py | 2 +-
+ tests/test_general.py  | 6 +++---
+ tests/test_write.py    | 2 +-
+ tests/test_xunit2.py   | 4 ++--
+ 5 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/tests/test_cli.py b/tests/test_cli.py
+index 86de610..828e57d 100644
+--- a/tests/test_cli.py
++++ b/tests/test_cli.py
+@@ -1,7 +1,7 @@
+ from pathlib import Path
+ import pytest
+-from src.junitparser import cli
+-from src.junitparser import version
++from junitparser import cli
++from junitparser import version
+ 
+ DATA_DIR = Path(__file__).parent / "data"
+ 
+diff --git a/tests/test_fromfile.py b/tests/test_fromfile.py
+index 73b8552..fb0d016 100644
+--- a/tests/test_fromfile.py
++++ b/tests/test_fromfile.py
+@@ -3,7 +3,7 @@ import pytest
+ import sys
+ from io import StringIO
+ from unittest import skipIf
+-from src.junitparser import (
++from junitparser import (
+     TestCase,
+     TestSuite,
+     Skipped,
+diff --git a/tests/test_general.py b/tests/test_general.py
+index 8d8c1d9..12cea9a 100644
+--- a/tests/test_general.py
++++ b/tests/test_general.py
+@@ -5,7 +5,7 @@ from unittest import skipIf
+ from xml.etree import ElementTree as etree
+ import pytest
+ 
+-from src.junitparser import (
++from junitparser import (
+     TestCase,
+     TestSuite,
+     Skipped,
+@@ -35,13 +35,13 @@ except ImportError:
+ class Test_XmlPackage:
+     @pytest.mark.skipif(has_lxml, reason="xml package is used unless lxml is installed")
+     def test_xml_etree(self):
+-        from src.junitparser.junitparser import etree as actual_etree
++        from junitparser.junitparser import etree as actual_etree
+ 
+         assert actual_etree == expected_xml_etree
+ 
+     @pytest.mark.skipif(not has_lxml, reason="lxml package has to be installed")
+     def test_lxml_etree(self):
+-        from src.junitparser.junitparser import etree as actual_etree
++        from junitparser.junitparser import etree as actual_etree
+ 
+         assert actual_etree == expected_lxml_etree
+ 
+diff --git a/tests/test_write.py b/tests/test_write.py
+index 5cc7362..fa004be 100644
+--- a/tests/test_write.py
++++ b/tests/test_write.py
+@@ -5,7 +5,7 @@ from io import BytesIO, StringIO
+ from tempfile import NamedTemporaryFile
+ from unittest import skipIf
+ 
+-from src.junitparser import TestCase, TestSuite, JUnitXmlError, JUnitXml
++from junitparser import TestCase, TestSuite, JUnitXmlError, JUnitXml
+ 
+ try:
+     from lxml.etree import XMLParser  # noqa: F401
+diff --git a/tests/test_xunit2.py b/tests/test_xunit2.py
+index e0440fc..2a8a33b 100644
+--- a/tests/test_xunit2.py
++++ b/tests/test_xunit2.py
+@@ -1,5 +1,5 @@
+ import textwrap
+-from src.junitparser.xunit2 import (
++from junitparser.xunit2 import (
+     JUnitXml,
+     TestSuite,
+     TestCase,
+@@ -8,7 +8,7 @@ from src.junitparser.xunit2 import (
+     FlakyFailure,
+     FlakyError,
+ )
+-from src.junitparser import Failure, Property
++from junitparser import Failure, Property
+ from copy import deepcopy
+ 
+ 
+-- 
+2.43.0
+

--- a/meta-ros-common/recipes-devtools/python3-junitparser/python3-junitparser/0002-ptest-Locale-en_US-de_DE-are-not-default-installed-i.patch
+++ b/meta-ros-common/recipes-devtools/python3-junitparser/python3-junitparser/0002-ptest-Locale-en_US-de_DE-are-not-default-installed-i.patch
@@ -1,0 +1,29 @@
+From a94c6f913673e8b26001876dd7b9118b1195ed2d Mon Sep 17 00:00:00 2001
+From: Jan Vermaete <jan.vermaete@oip.be>
+Date: Sun, 2 Aug 2026 14:48:09 +0200
+Subject: [PATCH 2/2] ptest: Locale en_US, de_DE are not default installed in
+ Yocto
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Jan Vermaete <jan.vermaete@oip.be>
+---
+ tests/test_general.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_general.py b/tests/test_general.py
+index 12cea9a..38171b6 100644
+--- a/tests/test_general.py
++++ b/tests/test_general.py
+@@ -99,7 +99,7 @@ def locale_fixture():
+ 
+ class Test_Locale:
+     @skipIf(os.name == "nt", "Not tested on Windows")
+-    @pytest.mark.parametrize("loc", ["", "en_US.UTF-8", "de_DE.UTF-8"])
++    @pytest.mark.parametrize("loc", [""])
+     def test_fromstring_numbers_locale_insensitive(self, loc, locale_fixture):
+         "Case relies on that LC_ALL is set in the console."
+         locale.setlocale(locale.LC_NUMERIC, loc)
+-- 
+2.43.0
+

--- a/meta-ros-common/recipes-devtools/python3-junitparser/python3-junitparser_5.0.1.bb
+++ b/meta-ros-common/recipes-devtools/python3-junitparser/python3-junitparser_5.0.1.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Parses JUnit/xUnit Result XML files with ease"
+HOMEPAGE = "https://junitparser.readthedocs.io"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=97e3403c3e32001abc4f414aefc752b7"
+
+SRC_URI = "\
+    git://github.com/weiwei/junitparser;protocol=https;branch=master \
+    file://0001-ptest-remove-the-src.-package.patch \
+    file://0002-ptest-Locale-en_US-de_DE-are-not-default-installed-i.patch \
+"
+
+SRCREV = "d98bdb70fbde4d08e191df17bd51576102c19d6a"
+
+inherit python_uv_build ptest-python-pytest


### PR DESCRIPTION
Rob: this one was missing in the meta layer and in the rosdistro/rosdep.

see: https://index.ros.org/d/python3-junitparser/
see:  https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L5141

Once this is merges I will send a PR to rosdistro too.

ptests are passing at RaspberryPi5:

    START: ptest-runner
    2026-06-26T10:41
    BEGIN: /usr/lib/python3-junitparser/ptest
    PASS: tests/test_cli.py:test_verify[jenkins.xml-1]
    PASS: tests/test_cli.py:test_verify[no_fails.xml-0]
    PASS: tests/test_cli.py:test_verify[normal.xml-1]
    PASS: tests/test_cli.py:test_merge
    PASS: tests/test_cli.py:test_merge_output_to_terminal
    PASS: tests/test_cli.py:test_verify_with_glob
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_version[-v]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_version[--version]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_help_shows_subcommands
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_subcommand_help[merge]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_subcommand_help[verify]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_subcommands_help_general_options[merge]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_subcommands_help_general_options[verify]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_merge_help_options
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_option_glob[merge]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_option_glob[verify]
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_verify_argument_path
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_merge_argument_path
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_merge_option_suite_name
    PASS: tests/test_cli.py:Test_CommandlineOptions.test_merge_argument_output
    PASS: tests/test_fromfile.py:test_fromfile
    PASS: tests/test_fromfile.py:test_fromfile_file_obj
    PASS: tests/test_fromfile.py:test_fromfile_filelike_obj
    SKIP: tests/test_fromfile.py:test_fromfile_url # SKIP lxml not installed
    PASS: tests/test_fromfile.py:test_fromfile_with_parser
    PASS: tests/test_fromfile.py:test_fromfile_without_testsuites_tag
    PASS: tests/test_fromfile.py:test_fromfile_with_testsuite_in_testsuite
    PASS: tests/test_fromfile.py:test_file_is_not_xml
    PASS: tests/test_fromfile.py:test_illegal_xml_file
    PASS: tests/test_fromfile.py:test_multi_results_in_case
    SKIP: tests/test_general.py:Test_XmlPackage.test_xml_etree # SKIP xml package is used unless lxml is installed
    PASS: tests/test_general.py:Test_XmlPackage.test_lxml_etree
    PASS: tests/test_general.py:Test_MergeSuiteCounts.test_merge_test_count
    PASS: tests/test_general.py:Test_MergeSuiteCounts.test_merge_same_suite
    PASS: tests/test_general.py:Test_Locale.test_fromstring_numbers_locale_insensitive[]
    PASS: tests/test_general.py:Test_JunitXml.test_fromstring
    PASS: tests/test_general.py:Test_JunitXml.test_fromstring_no_testsuites
    PASS: tests/test_general.py:Test_JunitXml.test_fromstring_multiple_fails
    PASS: tests/test_general.py:Test_JunitXml.test_fromroot_testsuite
    PASS: tests/test_general.py:Test_JunitXml.test_fromroot_testsuites
    PASS: tests/test_general.py:Test_JunitXml.test_fromstring_invalid
    PASS: tests/test_general.py:Test_JunitXml.test_add_suite
    PASS: tests/test_general.py:Test_JunitXml.test_construct_xml
    PASS: tests/test_general.py:Test_JunitXml.test_add_does_not_mutate_operands
    PASS: tests/test_general.py:Test_JunitXml.test_add
    PASS: tests/test_general.py:Test_JunitXml.test_add_same_suite
    PASS: tests/test_general.py:Test_JunitXml.test_iadd
    PASS: tests/test_general.py:Test_JunitXml.test_iadd_same_suite
    PASS: tests/test_general.py:Test_JunitXml.test_add_two_same_suites
    PASS: tests/test_general.py:Test_JunitXml.test_iadd_two_same_suites
    PASS: tests/test_general.py:Test_JunitXml.test_add_two_different_suites
    PASS: tests/test_general.py:Test_JunitXml.test_iadd_two_different_suites
    PASS: tests/test_general.py:Test_JunitXml.test_xml_statistics
    PASS: tests/test_general.py:Test_TestSuite.test_fromstring
    PASS: tests/test_general.py:Test_TestSuite.test_props_fromstring
    PASS: tests/test_general.py:Test_TestSuite.test_quoted_attr
    PASS: tests/test_general.py:Test_TestSuite.test_combining_testsuite_should_keep_name
    PASS: tests/test_general.py:Test_TestSuite.test_len
    PASS: tests/test_general.py:Test_TestSuite.test_add_case
    PASS: tests/test_general.py:Test_TestSuite.test_case_count
    PASS: tests/test_general.py:Test_TestSuite.test_add_property
    PASS: tests/test_general.py:Test_TestSuite.test_remove_case
    PASS: tests/test_general.py:Test_TestSuite.test_remove_property
    PASS: tests/test_general.py:Test_TestSuite.test_remove_property_from_none
    PASS: tests/test_general.py:Test_TestSuite.test_suite_in_suite
    PASS: tests/test_general.py:Test_TestSuite.test_case_time
    PASS: tests/test_general.py:Test_TestSuite.test_wrong_attr_type
    PASS: tests/test_general.py:Test_TestSuite.test_suite_eq
    PASS: tests/test_general.py:Test_TestSuite.test_suite_ne
    PASS: tests/test_general.py:Test_TestSuite.test_add_cases
    PASS: tests/test_general.py:Test_TestCase.test_case_fromstring
    PASS: tests/test_general.py:Test_TestCase.test_xml_multi_results
    PASS: tests/test_general.py:Test_TestCase.test_multi_results
    PASS: tests/test_general.py:Test_TestCase.test_case_attributes
    PASS: tests/test_general.py:Test_TestCase.test_case_init_with_attributes
    PASS: tests/test_general.py:Test_TestCase.test_case_output
    PASS: tests/test_general.py:Test_TestCase.test_update_results
    PASS: tests/test_general.py:Test_TestCase.test_monkypatch
    PASS: tests/test_general.py:Test_TestCase.test_equal
    PASS: tests/test_general.py:Test_TestCase.test_not_equal
    PASS: tests/test_general.py:Test_TestCase.test_from_elem
    PASS: tests/test_general.py:Test_TestCase.test_from_junit_elem
    PASS: tests/test_general.py:Test_TestCase.test_to_string
    PASS: tests/test_general.py:Test_TestCase.test_to_nonascii_string
    PASS: tests/test_general.py:Test_TestCase.test_system_out
    PASS: tests/test_general.py:Test_TestCase.test_system_err
    PASS: tests/test_general.py:Test_TestCase.test_result_eq
    PASS: tests/test_general.py:Test_TestCase.test_result_attrs
    PASS: tests/test_general.py:Test_TestCase.test_add_child_element
    PASS: tests/test_general.py:Test_TestCase.test_case_is_skipped
    PASS: tests/test_general.py:Test_TestCase.test_case_is_passed
    PASS: tests/test_general.py:Test_TestCase.test_case_is_failed
    PASS: tests/test_general.py:Test_TestCase.test_case_is_error
    PASS: tests/test_general.py:Test_Properties.test_property_repr1
    PASS: tests/test_general.py:Test_Properties.test_property_repr2
    PASS: tests/test_general.py:Test_Properties.test_property_eq
    PASS: tests/test_general.py:Test_Properties.test_property_ne
    PASS: tests/test_general.py:Test_Properties.test_properties_eq
    PASS: tests/test_general.py:Test_Properties.test_properties_ne
    PASS: tests/test_general.py:Test_Properties.test_properties_ne2
    PASS: tests/test_general.py:Test_Attrs.test_attr
    PASS: tests/test_write.py:test_write_xml_without_testsuite_tag
    PASS: tests/test_write.py:test_write
    PASS: tests/test_write.py:test_write_file_obj
    PASS: tests/test_write.py:test_write_stdout_stderr
    PASS: tests/test_write.py:test_write_stringio_bytesio
    PASS: tests/test_write.py:test_write_filelike_obj
    PASS: tests/test_write.py:test_write_noarg
    PASS: tests/test_write.py:test_write_nonascii
    PASS: tests/test_write.py:test_write_no_testsuites
    PASS: tests/test_write.py:test_read_written_xml
    PASS: tests/test_write.py:test_write_pretty
    PASS: tests/test_xunit2.py:Test_TestCase.test_case_rerun_fromstring
    PASS: tests/test_xunit2.py:Test_TestCase.test_case_flaky_fromstring
    PASS: tests/test_xunit2.py:Test_TestCase.test_case_rerun
    PASS: tests/test_xunit2.py:Test_TestCase.test_properties_and_output
    PASS: tests/test_xunit2.py:Test_TestCase.test_suite_parses_testcase_properties
    PASS: tests/test_xunit2.py:Test_TestCase.test_add_remove_property
    PASS: tests/test_xunit2.py:Test_TestSuite.test_properties
    PASS: tests/test_xunit2.py:Test_TestSuite.test_iterate_case
    PASS: tests/test_xunit2.py:Test_TestSuite.test_iterate_suite
    PASS: tests/test_xunit2.py:Test_TestSuite.test_remove_case
    PASS: tests/test_xunit2.py:Test_TestSuite.test_add_testsuites
    PASS: tests/test_xunit2.py:Test_TestSuite.test_iadd_testsuites
    PASS: tests/test_xunit2.py:Test_JUnitXml.test_init
    PASS: tests/test_xunit2.py:Test_JUnitXml.test_fromstring
    PASS: tests/test_xunit2.py:Test_JUnitXml.test_suite_fromstring
    ============================================================================
    Testsuite summary
    # TOTAL: 127
    # PASS: 125
    # SKIP: 2
    # XFAIL: 0
    # FAIL: 0
    # XPASS: 0
    # ERROR: 0
    DURATION: 1
    END: /usr/lib/python3-junitparser/ptest
    2026-06-26T10:41
    STOP: ptest-runner
    TOTAL: 1 FAIL: 0